### PR TITLE
Fixes #107 - state filters are searchable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -   Extent button now zooms to site markers
 -   Map zooms to sites when filters are submitted
+-   Made state filters searchable
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -   Extent button now zooms to site markers
 -   Map zooms to sites when filters are submitted
--   Made state filters searchable
+-   State filters are searchable
 
 ### Fixed
 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -69,6 +69,17 @@ describe('AppComponent', () => {
         component.dialog.closeAll();
     });
 
+    it(`#updateCurrentUser should be called on load`, () => {
+        spyOn(
+            component.currentUserService,
+            'updateCurrentUser'
+        ).and.callThrough();
+        component.ngOnInit();
+        expect(
+            component.currentUserService.updateCurrentUser
+        ).toHaveBeenCalled();
+    });
+
     it(`#logout should remove user data from localStorage`, () => {
         component.logout();
         expect(localStorage.getItem('username')).toBeNull();

--- a/src/app/app.utilities.ts
+++ b/src/app/app.utilities.ts
@@ -60,6 +60,26 @@ export class APP_UTILITIES {
             );
         }
     }
+    public static FILTER_STATE(state_name: any, states: State[]): State[] {
+        //state_name turns into the full state object when a state is selected
+        //when you're typing, your text will be matched, when you select a state, the object will be matched
+        if (typeof state_name == 'string') {
+            const filterValue = state_name.toLowerCase();
+            return states.filter(
+                (state) =>
+                    state.state_name.toLowerCase().indexOf(filterValue) === 0
+            );
+        } else {
+            if (state_name[0] !== undefined) {
+                const filterValue = state_name[0].state_name.toLowerCase();
+                return states.filter(
+                    (state) =>
+                        state.state_name.toLowerCase().indexOf(filterValue) ===
+                        0
+                );
+            }
+        }
+    }
     public static ROUND(num, len): any {
         return Math.round(num * Math.pow(10, len)) / Math.pow(10, len);
     }

--- a/src/app/app.utilities.ts
+++ b/src/app/app.utilities.ts
@@ -67,15 +67,15 @@ export class APP_UTILITIES {
             const filterValue = state_name.toLowerCase();
             return states.filter(
                 (state) =>
-                    state.state_name.toLowerCase().indexOf(filterValue) === 0
+                    state.state_name.toLowerCase().indexOf(filterValue) != -1
             );
         } else {
             if (state_name[0] !== undefined) {
                 const filterValue = state_name[0].state_name.toLowerCase();
                 return states.filter(
                     (state) =>
-                        state.state_name.toLowerCase().indexOf(filterValue) ===
-                        0
+                        state.state_name.toLowerCase().indexOf(filterValue) !=
+                        -1
                 );
             }
         }

--- a/src/app/interfaces/state.ts
+++ b/src/app/interfaces/state.ts
@@ -2,5 +2,6 @@ export interface State {
     state_id: number;
     state_name: string;
     state_abbrev: string;
-    counties:[];
+    counties: [];
+    selected?: boolean;
 }

--- a/src/app/map/map.component.html
+++ b/src/app/map/map.component.html
@@ -425,69 +425,6 @@
                         </div>
                     </div>
                 </mat-expansion-panel>
-                <!-- Results-->
-                <mat-expansion-panel>
-                    <mat-expansion-panel-header>
-                        <mat-panel-title> Results </mat-panel-title>
-                    </mat-expansion-panel-header>
-                    <div *ngIf="dataSource" class="results-table-div">
-                        <mat-table
-                            [dataSource]="dataSource"
-                            class="mat-elevation-z8"
-                        >
-                            <!-- Position Column -->
-                            <ng-container matColumnDef="position">
-                                <mat-header-cell *matHeaderCellDef>
-                                    No.
-                                </mat-header-cell>
-                                <mat-cell *matCellDef="let element">
-                                    {{ element.position }}
-                                </mat-cell>
-                            </ng-container>
-
-                            <!-- Name Column -->
-                            <ng-container matColumnDef="name">
-                                <mat-header-cell *matHeaderCellDef>
-                                    Name
-                                </mat-header-cell>
-                                <mat-cell *matCellDef="let element">
-                                    {{ element.name }}
-                                </mat-cell>
-                            </ng-container>
-
-                            <!-- Weight Column -->
-                            <ng-container matColumnDef="weight">
-                                <mat-header-cell *matHeaderCellDef>
-                                    Weight
-                                </mat-header-cell>
-                                <mat-cell *matCellDef="let element">
-                                    {{ element.weight }}
-                                </mat-cell>
-                            </ng-container>
-
-                            <!-- Symbol Column -->
-                            <ng-container matColumnDef="symbol">
-                                <mat-header-cell *matHeaderCellDef>
-                                    Symbol
-                                </mat-header-cell>
-                                <mat-cell *matCellDef="let element">
-                                    {{ element.symbol }}
-                                </mat-cell>
-                            </ng-container>
-
-                            <mat-header-row
-                                *matHeaderRowDef="displayedColumns"
-                            ></mat-header-row>
-                            <mat-row
-                                *matRowDef="let row; columns: displayedColumns"
-                            ></mat-row>
-                        </mat-table>
-
-                        <mat-paginator
-                            [pageSizeOptions]="[5, 10, 25]"
-                        ></mat-paginator>
-                    </div>
-                </mat-expansion-panel>
             </mat-card-content>
         </mat-card>
     </div>

--- a/src/app/map/map.component.html
+++ b/src/app/map/map.component.html
@@ -425,6 +425,7 @@
                         </div>
                     </div>
                 </mat-expansion-panel>
+                <app-filter-results></app-filter-results>
             </mat-card-content>
         </mat-card>
     </div>

--- a/src/app/map/map.component.html
+++ b/src/app/map/map.component.html
@@ -319,7 +319,7 @@
                             >
                                 <mat-option
                                     *ngFor="let state of states$ | async"
-                                    [value]="state"
+                                    [value]="state.state_abbrev"
                                 >
                                     <div (click)="optionClicked($event, state)">
                                         <mat-checkbox

--- a/src/app/map/map.component.html
+++ b/src/app/map/map.component.html
@@ -299,7 +299,7 @@
                                 </mat-select>
                             </mat-form-field>
 
-                            <mat-form-field>
+                            <mat-form-field appearance="fill">
                                 <mat-label for="stateList">States</mat-label>
                                 <input
                                     matInput
@@ -332,6 +332,8 @@
                                     </div>
                                 </mat-option>
                             </mat-autocomplete>
+
+                            <label id="selectedStateList"> </label>
 
                             <br />
                             <label

--- a/src/app/map/map.component.html
+++ b/src/app/map/map.component.html
@@ -298,20 +298,41 @@
                                     >
                                 </mat-select>
                             </mat-form-field>
-                            <mat-form-field appearance="fill">
+
+                            <mat-form-field>
                                 <mat-label for="stateList">States</mat-label>
-                                <mat-select
-                                    id="stateOptions"
+                                <input
+                                    matInput
+                                    type="text"
+                                    aria-label="Dropdown menu for state selection"
+                                    matInput
                                     formControlName="stateControl"
-                                    multiple
+                                    [matAutocomplete]="stateAutocomplete"
+                                />
+                                <mat-hint
+                                    >Start typing for suggestions</mat-hint
                                 >
-                                    <mat-option
-                                        *ngFor="let state of states$ | async"
-                                        [value]="state.state_abbrev"
-                                        >{{ state.state_name }}</mat-option
-                                    >
-                                </mat-select>
                             </mat-form-field>
+                            <mat-autocomplete
+                                #stateAutocomplete="matAutocomplete"
+                                [displayWith]="displayState"
+                            >
+                                <mat-option
+                                    *ngFor="let state of states$ | async"
+                                    [value]="state"
+                                >
+                                    <div (click)="optionClicked($event, state)">
+                                        <mat-checkbox
+                                            [checked]="state.selected"
+                                            (change)="toggleSelection(state)"
+                                            (click)="$event.stopPropagation()"
+                                        >
+                                            {{ state.state_name }}
+                                        </mat-checkbox>
+                                    </div>
+                                </mat-option>
+                            </mat-autocomplete>
+
                             <br />
                             <label
                                 class="filter-label"

--- a/src/app/map/map.component.html
+++ b/src/app/map/map.component.html
@@ -196,35 +196,6 @@
                                 </mat-select>
                             </mat-form-field>
 
-                            <mat-form-field appearance="fill">
-                                <mat-label for="eventType"
-                                    >Event State</mat-label
-                                >
-                                <input
-                                    matInput
-                                    id="eventStateOptions"
-                                    type="text"
-                                    aria-label="Dropdown menu for state selection"
-                                    matInput
-                                    formControlName="eventStateControl"
-                                    [matAutocomplete]="eventStateAutocomplete"
-                                />
-                                <mat-hint
-                                    >Start typing for suggestions</mat-hint
-                                >
-                                <mat-autocomplete
-                                    #eventStateAutocomplete="matAutocomplete"
-                                    [displayWith]="displayEventState"
-                                >
-                                    <mat-option
-                                        *ngFor="let state of states$ | async"
-                                        (click)="updateEventFilter()"
-                                        [value]="state"
-                                        >{{ state.state_name }}</mat-option
-                                    >
-                                </mat-autocomplete>
-                            </mat-form-field>
-
                             <br />
 
                             <mat-form-field class="eventSelect">

--- a/src/app/map/map.component.html
+++ b/src/app/map/map.component.html
@@ -321,10 +321,12 @@
                                     *ngFor="let state of states$ | async"
                                     [value]="state.state_abbrev"
                                 >
-                                    <div (click)="optionClicked($event, state)">
+                                    <div>
                                         <mat-checkbox
                                             [checked]="state.selected"
-                                            (change)="toggleSelection(state)"
+                                            (change)="
+                                                toggleStateSelection(state)
+                                            "
                                             (click)="$event.stopPropagation()"
                                         >
                                             {{ state.state_name }}
@@ -423,7 +425,69 @@
                         </div>
                     </div>
                 </mat-expansion-panel>
-                <app-filter-results></app-filter-results>
+                <!-- Results-->
+                <mat-expansion-panel>
+                    <mat-expansion-panel-header>
+                        <mat-panel-title> Results </mat-panel-title>
+                    </mat-expansion-panel-header>
+                    <div *ngIf="dataSource" class="results-table-div">
+                        <mat-table
+                            [dataSource]="dataSource"
+                            class="mat-elevation-z8"
+                        >
+                            <!-- Position Column -->
+                            <ng-container matColumnDef="position">
+                                <mat-header-cell *matHeaderCellDef>
+                                    No.
+                                </mat-header-cell>
+                                <mat-cell *matCellDef="let element">
+                                    {{ element.position }}
+                                </mat-cell>
+                            </ng-container>
+
+                            <!-- Name Column -->
+                            <ng-container matColumnDef="name">
+                                <mat-header-cell *matHeaderCellDef>
+                                    Name
+                                </mat-header-cell>
+                                <mat-cell *matCellDef="let element">
+                                    {{ element.name }}
+                                </mat-cell>
+                            </ng-container>
+
+                            <!-- Weight Column -->
+                            <ng-container matColumnDef="weight">
+                                <mat-header-cell *matHeaderCellDef>
+                                    Weight
+                                </mat-header-cell>
+                                <mat-cell *matCellDef="let element">
+                                    {{ element.weight }}
+                                </mat-cell>
+                            </ng-container>
+
+                            <!-- Symbol Column -->
+                            <ng-container matColumnDef="symbol">
+                                <mat-header-cell *matHeaderCellDef>
+                                    Symbol
+                                </mat-header-cell>
+                                <mat-cell *matCellDef="let element">
+                                    {{ element.symbol }}
+                                </mat-cell>
+                            </ng-container>
+
+                            <mat-header-row
+                                *matHeaderRowDef="displayedColumns"
+                            ></mat-header-row>
+                            <mat-row
+                                *matRowDef="let row; columns: displayedColumns"
+                            ></mat-row>
+                        </mat-table>
+
+                        <mat-paginator
+                            [pageSizeOptions]="[5, 10, 25]"
+                        ></mat-paginator>
+                    </div>
+                </mat-expansion-panel>
             </mat-card-content>
         </mat-card>
     </div>

--- a/src/app/map/map.component.html
+++ b/src/app/map/map.component.html
@@ -196,6 +196,38 @@
                                 </mat-select>
                             </mat-form-field>
 
+                            <mat-form-field appearance="fill">
+                                <mat-label for="eventType"
+                                    >Event State</mat-label
+                                >
+                                <input
+                                    matInput
+                                    id="eventStateOptions"
+                                    type="text"
+                                    aria-label="Dropdown menu for state selection"
+                                    matInput
+                                    formControlName="eventStateControl"
+                                    [matAutocomplete]="eventStateAutocomplete"
+                                />
+                                <mat-hint
+                                    >Start typing for suggestions</mat-hint
+                                >
+                                <mat-autocomplete
+                                    #eventStateAutocomplete="matAutocomplete"
+                                    [displayWith]="displayEventState"
+                                >
+                                    <mat-option
+                                        *ngFor="
+                                            let eventState of eventStates$
+                                                | async
+                                        "
+                                        (click)="updateEventFilter()"
+                                        [value]="eventState"
+                                        >{{ eventState.state_name }}</mat-option
+                                    >
+                                </mat-autocomplete>
+                            </mat-form-field>
+
                             <br />
 
                             <mat-form-field class="eventSelect">

--- a/src/app/map/map.component.html
+++ b/src/app/map/map.component.html
@@ -208,7 +208,6 @@
                                     matInput
                                     formControlName="eventStateControl"
                                     [matAutocomplete]="eventStateAutocomplete"
-                                    (selectionChange)="updateEventFilter()"
                                 />
                                 <mat-hint
                                     >Start typing for suggestions</mat-hint
@@ -219,6 +218,7 @@
                                 >
                                     <mat-option
                                         *ngFor="let state of states$ | async"
+                                        (click)="updateEventFilter()"
                                         [value]="state"
                                         >{{ state.state_name }}</mat-option
                                     >

--- a/src/app/map/map.component.html
+++ b/src/app/map/map.component.html
@@ -200,17 +200,29 @@
                                 <mat-label for="eventType"
                                     >Event State</mat-label
                                 >
-                                <mat-select
+                                <input
+                                    matInput
                                     id="eventStateOptions"
+                                    type="text"
+                                    aria-label="Dropdown menu for state selection"
+                                    matInput
                                     formControlName="eventStateControl"
+                                    [matAutocomplete]="eventStateAutocomplete"
                                     (selectionChange)="updateEventFilter()"
+                                />
+                                <mat-hint
+                                    >Start typing for suggestions</mat-hint
+                                >
+                                <mat-autocomplete
+                                    #eventStateAutocomplete="matAutocomplete"
+                                    [displayWith]="displayEventState"
                                 >
                                     <mat-option
                                         *ngFor="let state of states$ | async"
                                         [value]="state"
                                         >{{ state.state_name }}</mat-option
                                     >
-                                </mat-select>
+                                </mat-autocomplete>
                             </mat-form-field>
 
                             <br />

--- a/src/app/map/map.component.spec.ts
+++ b/src/app/map/map.component.spec.ts
@@ -206,8 +206,8 @@ describe('MapComponent', () => {
 
     it('should call updateEventFilter', () => {
         component.mapFilterForm.value.stateControl = 'NC';
-        //component.updateEventFilter();
-        expect(component.mapFilterForm.get('stateControl').value).toEqual('NC');
+        component.updateEventFilter();
+        //expect(component.mapFilterForm.get('stateControl').value).toEqual('NC');
     });
 
     it('#getDrawnItemPopupContent returns the appropriate content response', () => {
@@ -273,16 +273,22 @@ describe('MapComponent', () => {
     it('mapFilterForm should test all variations', () => {
         component.mapFilterForm.get('stateControl').setValue('NC');
         component.mapFilterForm.get('networkControl').setValue(['SWaTH']);
-        component.mapFilterForm.value.eventsControl = 7;
+
+        component.mapFilterForm.get('sensorOnlyControl').setValue('1');
+
+        component.mapFilterForm.get('eventsControl').setValue(7);
+
         component.mapFilterForm.value.sensorTypeControl = 'Webcam';
         component.mapFilterForm.value.surveyedControl = 'Surveyed';
         component.mapFilterForm.value.HWMOnlyControl = '1';
-        component.mapFilterForm.value.sensorOnlyControl = '1';
+        // component.mapFilterForm.value.sensorOnlyControl = '1';
         component.mapFilterForm.value.bracketSiteOnlyControl = '1';
         component.mapFilterForm.value.RDGOnlyControl = '1';
         component.mapFilterForm.value.OPDefinedControl = '1';
         component.submitMapFilter();
         expect(component.mapFilterForm).toBeTruthy;
+        expect(component.mapFilterForm.value.networkControl).toEqual(['SWaTH']);
+        //expect(component.mapResults).toHaveBeenCalled();
         //expect(component.submitMapFilter().urlParamString).toBe('Event=7&State=California&SensorType=Webcam&NetworkName=SWaTH&OPDefined=1&HWMOnly=');
     });
 

--- a/src/app/map/map.component.spec.ts
+++ b/src/app/map/map.component.spec.ts
@@ -169,8 +169,32 @@ describe('MapComponent', () => {
         );
     });
 
+    it('displayEventState returns the appropriate response', () => {
+        let state = {
+            counties: null,
+            selected: true,
+            state_abbrev: 'AK',
+            state_id: 2,
+            state_name: 'Alaska',
+        };
+        let response = component.displayEventState(state);
+        expect(response).toEqual(state && state.state_name);
+    });
+
     it('should call displaySelectedEvent', () => {
         component.displaySelectedEvent();
+    });
+
+    it('displayState returns null', () => {
+        let state = {
+            counties: null,
+            selected: true,
+            state_abbrev: 'AK',
+            state_id: 2,
+            state_name: 'Alaska',
+        };
+        let displayStateResponse = component.displayState(state);
+        expect(displayStateResponse).toEqual(null);
     });
 
     it('should call openZoomOutSnackBar', () => {
@@ -181,7 +205,9 @@ describe('MapComponent', () => {
     });
 
     it('should call updateEventFilter', () => {
-        component.updateEventFilter();
+        component.mapFilterForm.value.stateControl = 'NC';
+        //component.updateEventFilter();
+        expect(component.mapFilterForm.get('stateControl').value).toEqual('NC');
     });
 
     it('#getDrawnItemPopupContent returns the appropriate content response', () => {
@@ -216,10 +242,7 @@ describe('MapComponent', () => {
     });
 
     it('#eventFocus sets map to event focused view', () => {
-        // temporarily sets map to U.S, extent instead of event's extent
         // first set the view to somehting not default to test that the update works
-        // component.ngOnInit();
-        // component.createMap();
         let notDefaultCenter = new L.LatLng(55.8283, -125.5795);
         component.map.setView(notDefaultCenter, 9);
         component.eventFocus();
@@ -229,6 +252,18 @@ describe('MapComponent', () => {
         expect(mapZoom).toEqual(MAP_CONSTANTS.defaultZoom);
     });
 
+    it('mapFilterForm should be valid after toggleStateSelection', () => {
+        let state = {
+            counties: null,
+            selected: true,
+            state_abbrev: 'AK',
+            state_id: 2,
+            state_name: 'Alaska',
+        };
+        component.toggleStateSelection(state);
+        expect(component.mapFilterForm.valid).toBe(true);
+    });
+
     it('mapFilterForm should be a valid form on submit', () => {
         component.submitMapFilter();
         component.mapFilterForm.value.eventsControl = true;
@@ -236,10 +271,10 @@ describe('MapComponent', () => {
     });
 
     it('mapFilterForm should test all variations', () => {
+        component.mapFilterForm.get('stateControl').setValue('NC');
+        component.mapFilterForm.get('networkControl').setValue(['SWaTH']);
         component.mapFilterForm.value.eventsControl = 7;
-        component.mapFilterForm.value.networkControl = 'SWaTH';
         component.mapFilterForm.value.sensorTypeControl = 'Webcam';
-        component.mapFilterForm.value.stateControl = 'California';
         component.mapFilterForm.value.surveyedControl = 'Surveyed';
         component.mapFilterForm.value.HWMOnlyControl = '1';
         component.mapFilterForm.value.sensorOnlyControl = '1';
@@ -247,6 +282,7 @@ describe('MapComponent', () => {
         component.mapFilterForm.value.RDGOnlyControl = '1';
         component.mapFilterForm.value.OPDefinedControl = '1';
         component.submitMapFilter();
+        expect(component.mapFilterForm).toBeTruthy;
         //expect(component.submitMapFilter().urlParamString).toBe('Event=7&State=California&SensorType=Webcam&NetworkName=SWaTH&OPDefined=1&HWMOnly=');
     });
 

--- a/src/app/map/map.component.spec.ts
+++ b/src/app/map/map.component.spec.ts
@@ -21,6 +21,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatRadioModule } from '@angular/material/radio';
+import { of } from 'rxjs';
 
 // import { by } from '@angular/platform-browser';
 import {
@@ -42,6 +43,7 @@ import { APP_UTILITIES } from '@app/app.utilities';
 import { APP_SETTINGS } from '@app/app.settings';
 import { MAP_CONSTANTS } from './map-constants';
 import { DisplayValuePipe } from '@app/pipes/display-value.pipe';
+import { Site } from '@app/interfaces/site';
 
 describe('MapComponent', () => {
     let component: MapComponent;
@@ -169,6 +171,25 @@ describe('MapComponent', () => {
         );
     });
 
+    it('should call getEventSites and return events', () => {
+        const response: Site[] = [];
+        spyOn(component.siteService, 'getEventSites').and.returnValue(
+            of(response)
+        );
+        component.displaySelectedEvent();
+        fixture.detectChanges();
+        expect(component.sites).toEqual(response);
+    });
+
+    it('on load, should call getAllSites and return list of all sites', () => {
+        const response: Site[] = [];
+        spyOn(component.siteService, 'getAllSites').and.returnValue(
+            of(response)
+        );
+        fixture.detectChanges();
+        expect(component.sites).toEqual(response);
+    });
+
     it('displayEventState returns the appropriate response', () => {
         let state = {
             counties: null,
@@ -272,22 +293,18 @@ describe('MapComponent', () => {
 
     it('mapFilterForm should test all variations', () => {
         component.mapFilterForm.get('stateControl').setValue('NC');
-        component.mapFilterForm.get('networkControl').setValue(['SWaTH']);
-
+        component.mapFilterForm.get('networkControl').setValue([1, 2, 3]);
         component.mapFilterForm.get('sensorOnlyControl').setValue('1');
-
-        component.mapFilterForm.get('eventsControl').setValue(7);
-
-        component.mapFilterForm.value.sensorTypeControl = 'Webcam';
+        component.mapFilterForm.get('eventsControl').setValue(291);
+        component.mapFilterForm.get('sensorTypeControl').setValue('');
         component.mapFilterForm.value.surveyedControl = 'Surveyed';
         component.mapFilterForm.value.HWMOnlyControl = '1';
-        // component.mapFilterForm.value.sensorOnlyControl = '1';
         component.mapFilterForm.value.bracketSiteOnlyControl = '1';
         component.mapFilterForm.value.RDGOnlyControl = '1';
         component.mapFilterForm.value.OPDefinedControl = '1';
         component.submitMapFilter();
         expect(component.mapFilterForm).toBeTruthy;
-        expect(component.mapFilterForm.value.networkControl).toEqual(['SWaTH']);
+        expect(component.mapFilterForm.value.eventsControl).toEqual(291);
         //expect(component.mapResults).toHaveBeenCalled();
         //expect(component.submitMapFilter().urlParamString).toBe('Event=7&State=California&SensorType=Webcam&NetworkName=SWaTH&OPDefined=1&HWMOnly=');
     });

--- a/src/app/map/map.component.spec.ts
+++ b/src/app/map/map.component.spec.ts
@@ -44,6 +44,7 @@ import { APP_SETTINGS } from '@app/app.settings';
 import { MAP_CONSTANTS } from './map-constants';
 import { DisplayValuePipe } from '@app/pipes/display-value.pipe';
 import { Site } from '@app/interfaces/site';
+import { State } from '@app/interfaces/state';
 
 describe('MapComponent', () => {
     let component: MapComponent;
@@ -188,6 +189,27 @@ describe('MapComponent', () => {
         );
         fixture.detectChanges();
         expect(component.sites).toEqual(response);
+    });
+
+    it('should call getStates and return list of all states', () => {
+        const response: State[] = [];
+        spyOn(component.stateService, 'getStates').and.returnValue(
+            of(response)
+        );
+        component.getStates();
+        fixture.detectChanges();
+        expect(component.states).toEqual(response);
+        expect(component.eventStates).toEqual(response);
+    });
+
+    it('should call filterEvents and return list of filtered events', () => {
+        const response: Event[] = [];
+        spyOn(component.eventService, 'filterEvents').and.returnValue(
+            of(response)
+        );
+        component.updateEventFilter();
+        fixture.detectChanges();
+        expect(component.events).toEqual(response);
     });
 
     it('displayEventState returns the appropriate response', () => {

--- a/src/app/map/map.component.spec.ts
+++ b/src/app/map/map.component.spec.ts
@@ -171,7 +171,7 @@ describe('MapComponent', () => {
         );
     });
 
-    it('should call getEventSites and return events', () => {
+    it('should call getEventSites and return sites', () => {
         const response: Site[] = [];
         spyOn(component.siteService, 'getEventSites').and.returnValue(
             of(response)
@@ -226,9 +226,7 @@ describe('MapComponent', () => {
     });
 
     it('should call updateEventFilter', () => {
-        component.mapFilterForm.value.stateControl = 'NC';
         component.updateEventFilter();
-        //expect(component.mapFilterForm.get('stateControl').value).toEqual('NC');
     });
 
     it('#getDrawnItemPopupContent returns the appropriate content response', () => {

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -143,6 +143,7 @@ export class MapComponent implements OnInit {
     states: State[];
     eventStates: State[];
     selectedStates: State[] = new Array<State>();
+    stateList = '';
 
     eventTypes$: Observable<EventType[]>;
     filteredEvents$: Observable<Event[]>; //not used yet
@@ -362,7 +363,7 @@ export class MapComponent implements OnInit {
             );
             this.selectedStates.splice(i, 1);
         }
-
+        console.log('this.selectedStates', this.selectedStates);
         this.mapFilterForm.get('stateControl').setValue(this.selectedStates);
     }
     //Temporary message pop up at bottom of screen
@@ -757,14 +758,10 @@ export class MapComponent implements OnInit {
     }
     //will return a comma separated list of selected states
     displayState(state: any): string {
-        console.log('displayState, state', state);
-        // for (state_name in state) {
-        //   console.log(state_name);
-        // }
         let stateCount: number;
         let stateIndex: number;
-        let stateList = '';
         let currentState: string;
+        this.stateList = '';
         if (state !== null) {
             stateIndex = state.length;
             console.log(stateIndex);
@@ -774,12 +771,15 @@ export class MapComponent implements OnInit {
             currentState = state[stateCount].state_name;
             console.log('currentState', currentState);
             if (stateCount === 0) {
-                stateList = stateList.concat(currentState);
+                this.stateList = this.stateList.concat(
+                    ' Selected States: ' + currentState
+                );
             } else {
-                stateList = stateList.concat(', ' + currentState);
+                this.stateList = this.stateList.concat(', ' + currentState);
             }
         }
-        return stateList;
+        document.getElementById('selectedStateList').innerHTML = this.stateList;
+        return currentState;
     }
     //eventSites = the full site object to be mapped
     //myIcon = what the marker will look like

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -140,6 +140,7 @@ export class MapComponent implements OnInit {
 
     //holds filter values
     events: Event[];
+    states: State[];
 
     eventTypes$: Observable<EventType[]>;
     filteredEvents$: Observable<Event[]>; //not used yet
@@ -269,7 +270,21 @@ export class MapComponent implements OnInit {
         // get lists of options for dropdowns
         // this.networks$ = this.networkNamesService.getNetworkNames();
         // this.sensorTypes$ = this.sensorTypesService.getSensorTypes();
-        this.states$ = this.stateService.getStates();
+        this.stateService.getStates().subscribe((results) => {
+            this.states = results;
+            this.states$ = this.mapFilterForm
+                .get('eventStateControl')
+                .valueChanges.pipe(
+                    map((state_name) =>
+                        state_name
+                            ? APP_UTILITIES.FILTER_STATE(
+                                  state_name,
+                                  this.states
+                              )
+                            : this.states
+                    )
+                );
+        });
         // create and configure map
         this.createMap();
 
@@ -709,6 +724,10 @@ export class MapComponent implements OnInit {
     // options to be displayed when selecting event filter
     displayEvent(event: Event): string {
         return event && event.event_name ? event.event_name : '';
+    }
+    //will return a comma separated list of selected states
+    displayEventState(state: any): string {
+        return state && state.state_name ? state.state_name : '';
     }
 
     //eventSites = the full site object to be mapped

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -167,7 +167,7 @@ export class MapComponent implements OnInit {
         private networkNamesService: NetworkNameService,
         private sensorTypesService: SensorTypeService,
         public currentUserService: CurrentUserService,
-        private siteService: SiteService,
+        public siteService: SiteService,
         private displayValuePipe: DisplayValuePipe,
         public snackBar: MatSnackBar
     ) {
@@ -729,7 +729,6 @@ export class MapComponent implements OnInit {
     eventFocus() {
         //If there are site markers, zoom to those
         //Otherwise, zoom back to default extent
-        console.log('this.eventMarkers', this.eventMarkers);
         if (this.map.hasLayer(this.eventMarkers)) {
             this.map.fitBounds(this.eventMarkers.getBounds());
         } else {
@@ -924,8 +923,6 @@ export class MapComponent implements OnInit {
         this.siteService.getFilteredSites(urlParamString).subscribe((res) => {
             this.mapResults(res, this.eventIcon, this.eventMarkers, true);
         });
-        console.log('testing test', this.mapFilterForm.value.stateControl);
-        console.log('test2', this.mapFilterForm.get('stateControl').value);
         return urlParamString;
     }
 }

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -141,11 +141,13 @@ export class MapComponent implements OnInit {
     //holds filter values
     events: Event[];
     states: State[];
+    eventStates: State[];
 
     eventTypes$: Observable<EventType[]>;
     filteredEvents$: Observable<Event[]>; //not used yet
     networks$: Observable<NetworkName[]>;
     sensorTypes$: Observable<SensorType[]>;
+    eventStates$: Observable<State[]>;
     states$: Observable<State[]>;
 
     //These variables indicate if each layer is checked
@@ -194,6 +196,7 @@ export class MapComponent implements OnInit {
 
         this.networks$ = this.networkNameService.networks$;
         this.sensorTypes$ = this.sensorTypeService.sensorTypes$;
+        this.eventStates$ = this.stateService.eventStates$;
         this.states$ = this.stateService.states$;
 
         this.mapFilterForm = formBuilder.group({
@@ -262,9 +265,24 @@ export class MapComponent implements OnInit {
         // this.networks$ = this.networkNamesService.getNetworkNames();
         // this.sensorTypes$ = this.sensorTypesService.getSensorTypes();
         this.stateService.getStates().subscribe((results) => {
+            this.eventStates = results;
+            this.eventStates$ = this.mapFilterForm
+                .get('eventStateControl')
+                .valueChanges.pipe(
+                    map((state_name) =>
+                        state_name
+                            ? APP_UTILITIES.FILTER_STATE(
+                                  state_name,
+                                  this.eventStates
+                              )
+                            : this.eventStates
+                    )
+                );
+        });
+        this.stateService.getStates().subscribe((results) => {
             this.states = results;
             this.states$ = this.mapFilterForm
-                .get('eventStateControl')
+                .get('stateControl')
                 .valueChanges.pipe(
                     map((state_name) =>
                         state_name
@@ -740,11 +758,6 @@ export class MapComponent implements OnInit {
             for (const site of eventSites) {
                 const lat = Number(site.latitude_dd);
                 const long = Number(site.longitude_dd);
-                if (long < -103.3896) {
-                    if (lat < 29.7918 && lat > 29.6928) {
-                        console.log('SITE', site);
-                    }
-                }
 
                 /* let popupContent = '';
 

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -243,36 +243,8 @@ export class MapComponent implements OnInit {
         // get lists of options for dropdowns
         // this.networks$ = this.networkNamesService.getNetworkNames();
         // this.sensorTypes$ = this.sensorTypesService.getSensorTypes();
-        this.stateService.getStates().subscribe((results) => {
-            this.eventStates = results;
-            this.eventStates$ = this.mapFilterForm
-                .get('eventStateControl')
-                .valueChanges.pipe(
-                    map((state_name) =>
-                        state_name
-                            ? APP_UTILITIES.FILTER_STATE(
-                                  state_name,
-                                  this.eventStates
-                              )
-                            : this.eventStates
-                    )
-                );
-        });
-        this.stateService.getStates().subscribe((results) => {
-            this.states = results;
-            this.states$ = this.mapFilterForm
-                .get('stateControl')
-                .valueChanges.pipe(
-                    map((state_name) =>
-                        state_name
-                            ? APP_UTILITIES.FILTER_STATE(
-                                  state_name,
-                                  this.states
-                              )
-                            : this.states
-                    )
-                );
-        });
+        this.getStates();
+
         // create and configure map
         this.createMap();
 
@@ -297,6 +269,37 @@ export class MapComponent implements OnInit {
         this.currentFilter = localStorage.getItem('currentFilter')
             ? JSON.parse(localStorage.getItem('currentFilter'))
             : APP_SETTINGS.DEFAULT_FILTER_QUERY;
+    }
+
+    getStates() {
+        this.stateService.getStates().subscribe((results) => {
+            this.eventStates = results;
+            this.states = results;
+            this.eventStates$ = this.mapFilterForm
+                .get('eventStateControl')
+                .valueChanges.pipe(
+                    map((state_name) =>
+                        state_name
+                            ? APP_UTILITIES.FILTER_STATE(
+                                  state_name,
+                                  this.eventStates
+                              )
+                            : this.eventStates
+                    )
+                );
+            this.states$ = this.mapFilterForm
+                .get('stateControl')
+                .valueChanges.pipe(
+                    map((state_name) =>
+                        state_name
+                            ? APP_UTILITIES.FILTER_STATE(
+                                  state_name,
+                                  this.states
+                              )
+                            : this.states
+                    )
+                );
+        });
     }
 
     // TODO: update this
@@ -779,10 +782,6 @@ export class MapComponent implements OnInit {
         zoomToLayer: boolean
     ) {
         this.mapFilterForm.get('stateControl').setValue(this.selectedStates);
-        // set/reset resultsMarker var to an empty array
-        const markers = [];
-        const iconClass = ' wmm-icon-diamond wmm-icon-white ';
-        const riverConditions = [];
 
         // loop through results response from a search query
         if (eventSites.length !== undefined) {

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -365,8 +365,7 @@ export class MapComponent implements OnInit {
             );
             this.selectedStates.splice(i, 1);
         }
-        console.log('this.selectedStates', this.selectedStates);
-
+        //Create a string containing the list of state abbreviations
         if (this.selectedStates !== undefined) {
             numStates = this.selectedStates.length;
             for (let numAbbrev = 0; numAbbrev < numStates; numAbbrev++) {
@@ -381,8 +380,7 @@ export class MapComponent implements OnInit {
                 }
             }
         }
-        console.log('setAbbrev', this.setStateAbbrev);
-
+        //set the value of the state control to the full object of each state so that the list of state names can be displayed
         this.mapFilterForm.get('stateControl').setValue(this.selectedStates);
     }
     //Temporary message pop up at bottom of screen
@@ -523,7 +521,6 @@ export class MapComponent implements OnInit {
         // When layer is unchecked, remove layer icon from legend
         /* istanbul ignore next */
         this.map.on('overlayremove', (e) => {
-            console.log('this is e remove', e);
             if (e.name === 'Watersheds') {
                 this.watershedsVisible = false;
             }
@@ -733,7 +730,6 @@ export class MapComponent implements OnInit {
         // When layer is unchecked, remove layer icon from legend
         /* istanbul ignore next */
         this.map.on('overlayremove', (e) => {
-            console.log('this is e remove', e);
             if (e.name === 'Watersheds') {
                 this.watershedsVisible = false;
             }
@@ -776,6 +772,7 @@ export class MapComponent implements OnInit {
         return state && state.state_name ? state.state_name : '';
     }
     //will return a comma separated list of selected states
+    //prints list of states next to filter instead of filling the filter rectangle
     displayState(state: any): string {
         let stateCount: number;
         let stateIndex: number;
@@ -785,9 +782,7 @@ export class MapComponent implements OnInit {
             stateIndex = state.length;
         }
         for (stateCount = 0; stateCount < stateIndex; stateCount++) {
-            console.log('stateCount', stateCount, 'stateIndex', stateIndex);
             currentState = state[stateCount].state_name;
-            console.log('currentState', currentState);
             if (stateCount === 0) {
                 this.stateList = this.stateList.concat(
                     ' Selected States: ' + currentState
@@ -797,7 +792,7 @@ export class MapComponent implements OnInit {
             }
         }
         document.getElementById('selectedStateList').innerHTML = this.stateList;
-        return currentState;
+        return null;
     }
     //eventSites = the full site object to be mapped
     //myIcon = what the marker will look like
@@ -810,7 +805,7 @@ export class MapComponent implements OnInit {
         layerType: any,
         zoomToLayer: boolean
     ) {
-        document.getElementById('selectedStateList').innerHTML = '';
+        this.mapFilterForm.get('stateControl').setValue(this.selectedStates);
         // set/reset resultsMarker var to an empty array
         const markers = [];
         const iconClass = ' wmm-icon-diamond wmm-icon-white ';
@@ -878,7 +873,7 @@ export class MapComponent implements OnInit {
         }
         if (layerType == this.eventMarkers) {
             this.eventMarkers.addTo(this.map);
-            //When filtering sites, zoom to layer, close the filters pane and open map pane
+            //When filtering sites, zoom to layer, and open map pane
             if (zoomToLayer == true) {
                 this.eventFocus();
                 this.mapPanelState = true;
@@ -892,8 +887,11 @@ export class MapComponent implements OnInit {
     }
 
     public submitMapFilter() {
+        //close the filter panel
         this.filtersPanelState = false;
+        //set the state control to the state abbreviations
         this.mapFilterForm.get('stateControl').setValue(this.setStateAbbrev);
+
         let filterParams = JSON.parse(JSON.stringify(this.mapFilterForm.value));
 
         //collect and format selected Filter Form values
@@ -909,7 +907,6 @@ export class MapComponent implements OnInit {
         let stateAbbrevs = filterParams.stateControl
             ? filterParams.stateControl.toString()
             : '';
-        console.log('stateAbbrevs', stateAbbrevs);
         //surveyed = true, unsurveyed = false, or leave empty
         let surveyed = filterParams.surveyedControl
             ? filterParams.surveyedControl

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -142,6 +142,7 @@ export class MapComponent implements OnInit {
     events: Event[];
     states: State[];
     eventStates: State[];
+    selectedStates: State[] = new Array<State>();
 
     eventTypes$: Observable<EventType[]>;
     filteredEvents$: Observable<Event[]>; //not used yet
@@ -346,7 +347,24 @@ export class MapComponent implements OnInit {
         //     state: this.eventStateControl.value.state_abbrev,
         // });
     }
+    optionClicked(clickEvent: any, state: State) {
+        clickEvent.stopPropagation();
+        this.toggleSelection(state);
+    }
 
+    toggleSelection(state: State) {
+        state.selected = !state.selected;
+        if (state.selected) {
+            this.selectedStates.push(state);
+        } else {
+            const i = this.selectedStates.findIndex(
+                (value) => value.state_name === state.state_name
+            );
+            this.selectedStates.splice(i, 1);
+        }
+
+        this.mapFilterForm.get('stateControl').setValue(this.selectedStates);
+    }
     //Temporary message pop up at bottom of screen
     openZoomOutSnackBar(message: string, action: string, duration: number) {
         this.snackBar.open(message, action, {
@@ -736,6 +754,32 @@ export class MapComponent implements OnInit {
     //will return a comma separated list of selected states
     displayEventState(state: any): string {
         return state && state.state_name ? state.state_name : '';
+    }
+    //will return a comma separated list of selected states
+    displayState(state: any): string {
+        console.log('displayState, state', state);
+        // for (state_name in state) {
+        //   console.log(state_name);
+        // }
+        let stateCount: number;
+        let stateIndex: number;
+        let stateList = '';
+        let currentState: string;
+        if (state !== null) {
+            stateIndex = state.length;
+            console.log(stateIndex);
+        }
+        for (stateCount = 0; stateCount < stateIndex; stateCount++) {
+            console.log('stateCount', stateCount, 'stateIndex', stateIndex);
+            currentState = state[stateCount].state_name;
+            console.log('currentState', currentState);
+            if (stateCount === 0) {
+                stateList = stateList.concat(currentState);
+            } else {
+                stateList = stateList.concat(', ' + currentState);
+            }
+        }
+        return stateList;
     }
     //eventSites = the full site object to be mapped
     //myIcon = what the marker will look like

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -519,7 +519,6 @@ export class MapComponent implements OnInit {
                 }
             }
         });
-
         this.createDrawControls();
     }
 

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -144,6 +144,7 @@ export class MapComponent implements OnInit {
     eventStates: State[];
     selectedStates: State[] = new Array<State>();
     stateList = '';
+    setStateAbbrev = '';
 
     eventTypes$: Observable<EventType[]>;
     filteredEvents$: Observable<Event[]>; //not used yet
@@ -354,6 +355,7 @@ export class MapComponent implements OnInit {
     }
 
     toggleSelection(state: State) {
+        let numStates: number;
         state.selected = !state.selected;
         if (state.selected) {
             this.selectedStates.push(state);
@@ -364,6 +366,23 @@ export class MapComponent implements OnInit {
             this.selectedStates.splice(i, 1);
         }
         console.log('this.selectedStates', this.selectedStates);
+
+        if (this.selectedStates !== undefined) {
+            numStates = this.selectedStates.length;
+            for (let numAbbrev = 0; numAbbrev < numStates; numAbbrev++) {
+                if (numAbbrev === 0) {
+                    this.setStateAbbrev = this.setStateAbbrev.concat(
+                        this.selectedStates[numAbbrev].state_abbrev
+                    );
+                } else {
+                    this.setStateAbbrev = this.setStateAbbrev.concat(
+                        ',' + this.selectedStates[numAbbrev].state_abbrev
+                    );
+                }
+            }
+        }
+        console.log('setAbbrev', this.setStateAbbrev);
+
         this.mapFilterForm.get('stateControl').setValue(this.selectedStates);
     }
     //Temporary message pop up at bottom of screen
@@ -764,7 +783,6 @@ export class MapComponent implements OnInit {
         this.stateList = '';
         if (state !== null) {
             stateIndex = state.length;
-            console.log(stateIndex);
         }
         for (stateCount = 0; stateCount < stateIndex; stateCount++) {
             console.log('stateCount', stateCount, 'stateIndex', stateIndex);
@@ -792,6 +810,7 @@ export class MapComponent implements OnInit {
         layerType: any,
         zoomToLayer: boolean
     ) {
+        document.getElementById('selectedStateList').innerHTML = '';
         // set/reset resultsMarker var to an empty array
         const markers = [];
         const iconClass = ' wmm-icon-diamond wmm-icon-white ';
@@ -863,7 +882,6 @@ export class MapComponent implements OnInit {
             if (zoomToLayer == true) {
                 this.eventFocus();
                 this.mapPanelState = true;
-                this.filtersPanelState = false;
             }
         }
     }
@@ -874,6 +892,8 @@ export class MapComponent implements OnInit {
     }
 
     public submitMapFilter() {
+        this.filtersPanelState = false;
+        this.mapFilterForm.get('stateControl').setValue(this.setStateAbbrev);
         let filterParams = JSON.parse(JSON.stringify(this.mapFilterForm.value));
 
         //collect and format selected Filter Form values
@@ -889,6 +909,7 @@ export class MapComponent implements OnInit {
         let stateAbbrevs = filterParams.stateControl
             ? filterParams.stateControl.toString()
             : '';
+        console.log('stateAbbrevs', stateAbbrevs);
         //surveyed = true, unsurveyed = false, or leave empty
         let surveyed = filterParams.surveyedControl
             ? filterParams.surveyedControl

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -157,9 +157,9 @@ export class MapComponent implements OnInit {
     //      2) setup a better way to store the state of the data - NgRx.This ought to replace storing it in an object local to this component,
     //       but this local store ok for the short term. The data table should be independent of that data store solution.
     constructor(
-        private eventService: EventService,
+        public eventService: EventService,
         private eventTypeService: EventTypeService,
-        private stateService: StateService,
+        public stateService: StateService,
         private networkNameService: NetworkNameService,
         private sensorTypeService: SensorTypeService,
         private eventsService: EventService,

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -325,12 +325,8 @@ export class MapComponent implements OnInit {
         //     state: this.eventStateControl.value.state_abbrev,
         // });
     }
-    optionClicked(clickEvent: any, state: State) {
-        clickEvent.stopPropagation();
-        this.toggleSelection(state);
-    }
 
-    toggleSelection(state: State) {
+    toggleStateSelection(state: State) {
         let numStates: number;
         state.selected = !state.selected;
         if (state.selected) {
@@ -730,6 +726,7 @@ export class MapComponent implements OnInit {
     eventFocus() {
         //If there are site markers, zoom to those
         //Otherwise, zoom back to default extent
+        console.log('this.eventMarkers', this.eventMarkers);
         if (this.map.hasLayer(this.eventMarkers)) {
             this.map.fitBounds(this.eventMarkers.getBounds());
         } else {
@@ -928,6 +925,8 @@ export class MapComponent implements OnInit {
         this.siteService.getFilteredSites(urlParamString).subscribe((res) => {
             this.mapResults(res, this.eventIcon, this.eventMarkers, true);
         });
+        console.log('testing test', this.mapFilterForm.value.stateControl);
+        console.log('test2', this.mapFilterForm.get('stateControl').value);
         return urlParamString;
     }
 }

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -729,7 +729,6 @@ export class MapComponent implements OnInit {
     displayEventState(state: any): string {
         return state && state.state_name ? state.state_name : '';
     }
-
     //eventSites = the full site object to be mapped
     //myIcon = what the marker will look like
     //layerType = empty leaflet layer type

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -740,6 +740,11 @@ export class MapComponent implements OnInit {
             for (const site of eventSites) {
                 const lat = Number(site.latitude_dd);
                 const long = Number(site.longitude_dd);
+                if (long < -103.3896) {
+                    if (lat < 29.7918 && lat > 29.6928) {
+                        console.log('SITE', site);
+                    }
+                }
 
                 /* let popupContent = '';
 

--- a/src/app/services/state.service.ts
+++ b/src/app/services/state.service.ts
@@ -15,8 +15,19 @@ import { APP_UTILITIES } from '@app/app.utilities';
 })
 export class StateService {
     states$: Observable<any>;
+    eventStates$: Observable<any>;
     constructor(private httpClient: HttpClient) {
         this.states$ = httpClient.get(APP_SETTINGS.STATES + '.json').pipe(
+            shareReplay(1),
+            tap(() => console.log('after sharing')),
+            catchError(
+                APP_UTILITIES.handleError<any>(
+                    'StateService httpClient GET',
+                    []
+                )
+            )
+        );
+        this.eventStates$ = httpClient.get(APP_SETTINGS.STATES + '.json').pipe(
             shareReplay(1),
             tap(() => console.log('after sharing')),
             catchError(


### PR DESCRIPTION
Right now I have it printing a list of all the selected states for the multiselect next to, instead of inside of, the filter because they were getting cutoff. The aesthetics are not great:
![image](https://user-images.githubusercontent.com/46943254/102507839-51db0d80-404a-11eb-956a-49ac5d744259.png)
I started with trying chips, and saw Issue #113 is about making chips for all the filters, so I thought I'd do it there/after Mitch moves things around - or I could make edits here if you have layout ideas