### PR TITLE
Issue #145 - ask user to select a filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -   Added popup on site click with site information
 -   Added warning message when user's query returns no data
 -   Added Login capability
+-   Added requirement for user to select at least one of Event, State, Network, or Sensor filter
 
 ### Changed
 

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -906,6 +906,7 @@ export class MapComponent implements OnInit {
                 'OK',
                 4500
             );
+            //If the user has at least one Event, Network, Sensor, or State filter select, continue with http request
         } else {
             // format url params into single string
             let urlParamString =

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -350,7 +350,7 @@ export class MapComponent implements OnInit {
         });
     }
     //Temporary message pop up when user's query returns no data
-    noDataSnackBar(message: string, action: string, duration: number) {
+    filtersSnackBar(message: string, action: string, duration: number) {
         this.snackBar.open(message, action, {
             duration: duration,
             panelClass: ['no-data-warning'],
@@ -893,54 +893,76 @@ export class MapComponent implements OnInit {
         let RDGTrue = filterParams.RDGOnlyControl ? '1' : '';
         let opDefinedTrue = filterParams.OPDefinedControl ? '1' : '';
 
-        // format url params into single string
-        let urlParamString =
-            'Event=' +
-            eventId +
-            '&State=' +
-            stateAbbrevs +
-            '&SensorType=' +
-            sensorIds +
-            '&NetworkName=' +
-            networkIds +
-            '&OPDefined=' +
-            opDefinedTrue +
-            '&HWMOnly=' +
-            HWMTrue +
-            '&HWMSurveyed=' +
-            surveyed +
-            '&SensorOnly=' +
-            sensorTrue +
-            '&RDGOnly=' +
-            RDGTrue +
-            '&HousingTypeOne=' +
-            bracketTrue;
+        //Too few filters can lead to too many sites and a slow response time
+        //Force the user to select at least one of the following filters
+        if (
+            eventId == '' &&
+            networkIds == '' &&
+            sensorIds == '' &&
+            stateAbbrevs == ''
+        ) {
+            this.filtersSnackBar(
+                'Please select at least one Event, Network, Sensor, or State filter.',
+                'OK',
+                4500
+            );
+        } else {
+            // format url params into single string
+            let urlParamString =
+                'Event=' +
+                eventId +
+                '&State=' +
+                stateAbbrevs +
+                '&SensorType=' +
+                sensorIds +
+                '&NetworkName=' +
+                networkIds +
+                '&OPDefined=' +
+                opDefinedTrue +
+                '&HWMOnly=' +
+                HWMTrue +
+                '&HWMSurveyed=' +
+                surveyed +
+                '&SensorOnly=' +
+                sensorTrue +
+                '&RDGOnly=' +
+                RDGTrue +
+                '&HousingTypeOne=' +
+                bracketTrue;
 
-        //Clear current markers when a new filter is submitted
-        if (this.map.hasLayer(this.eventMarkers)) {
-            this.eventMarkers.removeFrom(this.map);
-            this.eventMarkers = L.featureGroup([]);
-        }
-        //Find sites that match the user's query
-        this.siteService.getFilteredSites(urlParamString).subscribe((res) => {
-            //set the state control back to state names instead of abbreviations
-            this.mapFilterForm
-                .get('stateControl')
-                .setValue(this.selectedStates);
-            //only call mapResults if the query returns data
-            if (res.length > 0) {
-                //close the filter panel
-                this.filtersPanelState = false;
-                this.mapResults(res, this.eventIcon, this.eventMarkers, true);
-            } else {
-                //if nothing is returned, show a snack bar message
-                this.noDataSnackBar(
-                    'No results for your query. Try using fewer filters.',
-                    'OK',
-                    4500
-                );
+            //Clear current markers when a new filter is submitted
+            if (this.map.hasLayer(this.eventMarkers)) {
+                this.eventMarkers.removeFrom(this.map);
+                this.eventMarkers = L.featureGroup([]);
             }
-        });
-        return urlParamString;
+            //Find sites that match the user's query
+            this.siteService
+                .getFilteredSites(urlParamString)
+                .subscribe((res) => {
+                    //set the state control back to state names instead of abbreviations
+                    this.mapFilterForm
+                        .get('stateControl')
+                        .setValue(this.selectedStates);
+                    //only call mapResults if the query returns data
+                    if (res.length > 0) {
+                        //close the filter panel
+                        this.filtersPanelState = false;
+                        this.mapResults(
+                            res,
+                            this.eventIcon,
+                            this.eventMarkers,
+                            true
+                        );
+                    } else {
+                        //if nothing is returned, show a snack bar message
+                        this.filtersSnackBar(
+                            'No results for your query. Try using fewer filters.',
+                            'OK',
+                            4500
+                        );
+                    }
+                });
+            return urlParamString;
+        }
     }
 }


### PR DESCRIPTION
Selected only one of most of the Additional site filters or just surveyed/unsurveyed also led to the app crashing or moving very slowly, so right now I'm forcing users to choose at least one event, network, sensor, or state. 