### PR TITLE
imports noopAnimations to login component

### DIFF
--- a/src/app/login/login.component.spec.ts
+++ b/src/app/login/login.component.spec.ts
@@ -20,6 +20,7 @@ import { AuthenticationService } from '@app/services/authentication.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { CurrentUserService } from '@app/services/current-user.service';
 import { APP_SETTINGS } from '@app/app.settings';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('LoginComponent', () => {
     let component: LoginComponent;
@@ -38,6 +39,7 @@ describe('LoginComponent', () => {
                 HttpClientTestingModule,
                 OverlayModule,
                 MatDialogModule,
+                NoopAnimationsModule,
             ],
             declarations: [LoginComponent],
             providers: [

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -37,6 +37,7 @@ import { SiteService } from '@services/site.service';
 import { FiltersService } from '@services/filters.service';
 import 'leaflet.markercluster';
 import 'leaflet.markercluster.freezable';
+
 import { FilteredEventsQuery } from '@interfaces/filtered-events-query';
 
 import { MatInputModule } from '@angular/material/input';


### PR DESCRIPTION
I am hoping this fixes it - it's passed lots of times locally now 🤞 
If I'm understanding correctly, it needed to be imported to spec files of all the components that use the mat snackbar, since mat snackbar implicitly uses browser animations. The noop animations are only used in spec files to mimic the animation when not directly testing the animation itself. 