### PR TITLE
Fixes #174 - uses marker clusters for large queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
--   Used marker clusters for filters returned at least 500 sites
+-   Switched to marker clusters for large queries
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
--
+-   Used marker clusters for filters returned at least 500 sites
 
 ### Fixed
 

--- a/src/app/map/map.component.html
+++ b/src/app/map/map.component.html
@@ -22,7 +22,7 @@
                 <div
                     id="extentBtn"
                     class="extentBtn leaflet-bar leaflet-control leaflet-control-zoom"
-                    (click)="eventFocus()"
+                    (click)="siteFocus()"
                     aria-label="Clicking this button zooms to the extent of selected event"
                 >
                     <mat-icon aria-hidden="false" aria-label="Example home icon"
@@ -58,13 +58,23 @@
                 <mat-expansion-panel-header>
                     <mat-panel-title> Legend </mat-panel-title>
                 </mat-expansion-panel-header>
-                <div class="legend-panel-content" *ngIf="sitesVisible">
-                    <div id="sitesLegend">
-                        <div class="legend-icon">
-                            <div
-                                class="wmm-pin wmm-altblue wmm-icon-circle wmm-icon-white wmm-size-20"
-                            ></div>
-                            <label>Site</label>
+                <div *ngIf="sitesVisible">
+                    <div class="legend-panel-content" *ngIf="!manyFiltered">
+                        <div id="sitesLegend">
+                            <div class="legend-icon">
+                                <div
+                                    class="wmm-pin wmm-altblue wmm-icon-circle wmm-icon-white wmm-size-20"
+                                ></div>
+                                <label>Site</label>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="legend-panel-content" *ngIf="manyFiltered">
+                        <div id="sitesLegend">
+                            <div class="legend-icon allSitesLegend">
+                                <div class="manyFilteredSitesIcon"></div>
+                                <label class="allSitesLegendLabel">Site</label>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/src/app/map/map.component.spec.ts
+++ b/src/app/map/map.component.spec.ts
@@ -350,17 +350,6 @@ describe('MapComponent', () => {
         component.updateEventFilter();
     });
 
-    it('#siteFocus sets map to event focused view', () => {
-        // first set the view to somehting not default to test that the update works
-        let notDefaultCenter = new L.LatLng(55.8283, -125.5795);
-        component.map.setView(notDefaultCenter, 9);
-        component.siteFocus();
-        let mapCenter = component.map.getCenter();
-        let mapZoom = component.map.getZoom();
-        expect(mapCenter).toEqual(MAP_CONSTANTS.defaultCenter);
-        expect(mapZoom).toEqual(MAP_CONSTANTS.defaultZoom);
-    });
-
     it('mapFilterForm should be valid after toggleStateSelection', () => {
         let state = {
             counties: null,

--- a/src/app/map/map.component.spec.ts
+++ b/src/app/map/map.component.spec.ts
@@ -350,11 +350,11 @@ describe('MapComponent', () => {
         component.updateEventFilter();
     });
 
-    it('#eventFocus sets map to event focused view', () => {
+    it('#siteFocus sets map to event focused view', () => {
         // first set the view to somehting not default to test that the update works
         let notDefaultCenter = new L.LatLng(55.8283, -125.5795);
         component.map.setView(notDefaultCenter, 9);
-        component.eventFocus();
+        component.siteFocus();
         let mapCenter = component.map.getCenter();
         let mapZoom = component.map.getZoom();
         expect(mapCenter).toEqual(MAP_CONSTANTS.defaultCenter);

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -822,7 +822,12 @@ export class MapComponent implements OnInit {
             this.map.fitBounds(
                 this.siteService.manyFilteredSitesMarkers.getBounds()
             );
-        } else {
+        } else if (
+            this.map.hasLayer(
+                this.siteService.manyFilteredSitesMarkers === false &&
+                    this.map.hasLayer(this.siteService.siteMarkers) === false
+            )
+        ) {
             this.map.setView(
                 MAP_CONSTANTS.defaultCenter,
                 MAP_CONSTANTS.defaultZoom

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -178,6 +178,11 @@ export class MapComponent implements OnInit {
         iconSize: 32,
     });
 
+    manyFilteredSitesIcon = L.divIcon({
+        className: 'manyFilteredSitesMarkers',
+        iconSize: 32,
+    });
+
     //supplementary layers
     HUC = esri.dynamicMapLayer({
         url: 'https://hydro.nationalmap.gov/arcgis/rest/services/wbd/MapServer',
@@ -637,9 +642,11 @@ export class MapComponent implements OnInit {
             //Disable clustering for the All STN Sites layer when zoom >= 12 so we can see individual sites
             if (this.currentZoom >= 12) {
                 this.siteService.allSiteMarkers.disableClustering();
+                this.siteService.manyFilteredSitesMarkers.disableClustering();
             }
             if (this.currentZoom < 12) {
                 this.siteService.allSiteMarkers.enableClustering();
+                this.siteService.manyFilteredSitesMarkers.enableClustering();
             }
             //If the zoom went from 9 to 8 and the gages/watches/warnings are on,
             //that layer is checked, but it's not displayed
@@ -904,7 +911,11 @@ export class MapComponent implements OnInit {
                         site.site_no !== 'AZGRA27856'
                     ) {
                         //put all the site markers in the same layer group
-                        if (layerType == this.siteService.siteMarkers) {
+                        if (
+                            layerType === this.siteService.siteMarkers ||
+                            layerType ===
+                                this.siteService.manyFilteredSitesMarkers
+                        ) {
                             L.marker([lat, long], { icon: myIcon })
                                 .bindPopup(popupContent)
                                 .addTo(layerType);
@@ -922,8 +933,12 @@ export class MapComponent implements OnInit {
                 }
             }
         }
-        if (layerType == this.siteService.siteMarkers) {
+        if (
+            layerType == this.siteService.siteMarkers ||
+            layerType === this.siteService.manyFilteredSitesMarkers
+        ) {
             this.siteService.siteMarkers.addTo(this.map);
+            this.siteService.manyFilteredSitesMarkers.addTo(this.map);
             //When filtering sites, zoom to layer, and open map pane
 
             //if there are multiple queries, wait until the last one to zoom to the layer
@@ -1100,8 +1115,8 @@ export class MapComponent implements OnInit {
                                 this.currentQuery += 1;
                                 this.mapResults(
                                     uniqueSites,
-                                    this.eventIcon,
-                                    this.siteService.siteMarkers,
+                                    this.manyFilteredSitesIcon,
+                                    this.siteService.manyFilteredSitesMarkers,
                                     true
                                 );
                             });

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -174,7 +174,7 @@ export class MapComponent implements OnInit {
             ' wmm-pin wmm-altblue wmm-icon-circle wmm-icon-white wmm-size-20',
     });
     //for the All STN Sites layer
-    siteIcon = L.divIcon({
+    allSiteIcon = L.divIcon({
         className: ' allSiteIcon ',
         iconSize: 32,
     });
@@ -372,7 +372,7 @@ export class MapComponent implements OnInit {
             this.resultsReturned = true;
             this.mapResults(
                 this.allSites,
-                this.siteIcon,
+                this.allSiteIcon,
                 this.siteService.allSiteMarkers,
                 false
             );
@@ -812,7 +812,6 @@ export class MapComponent implements OnInit {
     }
 
     siteFocus() {
-        console.log('hit siteFocus');
         //If there are site markers, zoom to those
         //Otherwise, zoom back to default extent
         if (this.map.hasLayer(this.siteService.siteMarkers)) {
@@ -1152,6 +1151,7 @@ export class MapComponent implements OnInit {
                                     }
                                 }
                                 this.currentQuery += 1;
+                                //map results after network is complete
                                 if (this.currentQuery === this.totalQueries) {
                                     this.getFilterResults(uniqueSites);
                                 }

--- a/src/app/services/site.service.ts
+++ b/src/app/services/site.service.ts
@@ -83,7 +83,7 @@ export class SiteService {
 
     public manyFilteredSitesMarkers = new L.markerClusterGroup({
         showCoverageOnHover: false,
-        maxClusterRadius: 40,
+        maxClusterRadius: 25,
         iconCreateFunction: function (cluster) {
             var markers = cluster.getAllChildMarkers();
             var html =

--- a/src/app/services/site.service.ts
+++ b/src/app/services/site.service.ts
@@ -96,7 +96,6 @@ export class SiteService {
                 iconSize: L.point(32, 32),
             });
         },
-        // spiderfyDistanceMultiplier: 2,
     });
 
     public siteMarkers = new L.featureGroup([]);
@@ -108,6 +107,15 @@ export class SiteService {
     }
     public allSiteMarker(): Observable<any> {
         return this._allallSiteMarkers.asObservable();
+    }
+
+    private _filteredSiteMarkers: Subject<any> = new Subject<any>();
+    public setFilteredSiteMarkers(val: any) {
+        this.manyFilteredSitesMarkers = val;
+        this._filteredSiteMarkers.next(val);
+    }
+    public filteredSiteMarker(): Observable<any> {
+        return this._filteredSiteMarkers.asObservable();
     }
 
     /**

--- a/src/app/services/site.service.ts
+++ b/src/app/services/site.service.ts
@@ -109,13 +109,13 @@ export class SiteService {
         return this._allallSiteMarkers.asObservable();
     }
 
-    private _filteredSiteMarkers: Subject<any> = new Subject<any>();
-    public setFilteredSiteMarkers(val: any) {
+    private _manyFilteredSiteMarkers: Subject<any> = new Subject<any>();
+    public setManyFilteredSiteMarkers(val: any) {
         this.manyFilteredSitesMarkers = val;
-        this._filteredSiteMarkers.next(val);
+        this._manyFilteredSiteMarkers.next(val);
     }
-    public filteredSiteMarker(): Observable<any> {
-        return this._filteredSiteMarkers.asObservable();
+    public manyFilteredSiteMarker(): Observable<any> {
+        return this._manyFilteredSiteMarkers.asObservable();
     }
 
     /**

--- a/src/app/services/site.service.ts
+++ b/src/app/services/site.service.ts
@@ -81,6 +81,24 @@ export class SiteService {
         // spiderfyDistanceMultiplier: 2,
     });
 
+    public manyFilteredSitesMarkers = new L.markerClusterGroup({
+        showCoverageOnHover: false,
+        maxClusterRadius: 40,
+        iconCreateFunction: function (cluster) {
+            var markers = cluster.getAllChildMarkers();
+            var html =
+                '<div style="text-align: center; margin-top: 7px; color: white">' +
+                markers.length +
+                '</div>';
+            return L.divIcon({
+                html: html,
+                className: 'manyFilteredSitesIcon',
+                iconSize: L.point(32, 32),
+            });
+        },
+        // spiderfyDistanceMultiplier: 2,
+    });
+
     public siteMarkers = new L.featureGroup([]);
 
     private _allallSiteMarkers: Subject<any> = new Subject<any>();

--- a/src/assets/styles/makers.css
+++ b/src/assets/styles/makers.css
@@ -851,6 +851,21 @@
     opacity: 1;
 }
 
+.manyFilteredSitesIcon {
+    height: 32px;
+    border-radius: 50%;
+    -moz-border-radius: 50%;
+    -webkit-border-radius: 50%;
+    width: 32px;
+    display: block;
+    overflow: hidden;
+    position: absolute;
+    margin-top: 6px;
+    background-color: #2346f6;
+    border: 2px solid rgba(0, 0, 0, 0.5);
+    opacity: 1;
+}
+
 .testcircle {
     width: 32px;
     height: 32px;


### PR DESCRIPTION
I arbitrability chose 500 as the threshold (can be easily adjusted) for using clusters instead of 3 networks since lots of networks combined with other filters sometimes doesn't return much.

We can also revisit the icon. Right now, I just have a circle and took the colors from the WIM pin. Legend updates to reflect changes.
![image](https://user-images.githubusercontent.com/46943254/105749287-d1d97a80-5f08-11eb-9383-2bbd5b70ed34.png)
