### PR TITLE
Fixes #172 and #173 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -   Switched to marker clusters for large queries
 -   Results panel opens when filter is submitted
+-   Site markers clear when click "Clear Filters"
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 -   Switched to marker clusters for large queries
+-   Results panel opens when filter is submitted
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
--   Used marker clusters for filters returned at least 500 sites
+-   Switched to marker clusters for large queries
 
 ### Fixed
 

--- a/src/app/filter-results/filter-results.component.html
+++ b/src/app/filter-results/filter-results.component.html
@@ -1,5 +1,5 @@
 <!-- Results-->
-<mat-expansion-panel>
+<mat-expansion-panel [(expanded)]="resultsPanelOpen">
     <mat-expansion-panel-header>
         <mat-panel-title> Results </mat-panel-title>
     </mat-expansion-panel-header>

--- a/src/app/filter-results/filter-results.component.ts
+++ b/src/app/filter-results/filter-results.component.ts
@@ -4,6 +4,7 @@ import { MatPaginator } from '@angular/material/paginator';
 import { MatSort } from '@angular/material/sort';
 import { Sort } from '@angular/material/sort';
 import { FiltersService } from '@services/filters.service';
+import { BehaviorSubject, Subscription } from 'rxjs';
 
 @Component({
     selector: 'app-filter-results',
@@ -17,6 +18,8 @@ export class FilterResultsComponent implements OnInit {
     dataSource = new MatTableDataSource([]);
     sortedData = [];
     currentSites;
+    resultsPanelOpen: boolean = true;
+    subscription: Subscription;
 
     // columns for results table
     displayedColumns: string[] = [
@@ -34,6 +37,10 @@ export class FilterResultsComponent implements OnInit {
     constructor(private filtersService: FiltersService) {
         this.filtersService.selectedSites.subscribe(
             (currentSites) => (this.currentSites = currentSites)
+        );
+
+        this.subscription = this.filtersService.resultsPanelOpen.subscribe(
+            (state) => (this.resultsPanelOpen = state)
         );
     }
 

--- a/src/app/map/map.component.spec.ts
+++ b/src/app/map/map.component.spec.ts
@@ -350,17 +350,6 @@ describe('MapComponent', () => {
         component.updateEventFilter();
     });
 
-    it('#siteFocus sets map to event focused view', () => {
-        // first set the view to somehting not default to test that the update works
-        let notDefaultCenter = new L.LatLng(55.8283, -125.5795);
-        component.map.setView(notDefaultCenter, 9);
-        component.siteFocus();
-        let mapCenter = component.map.getCenter();
-        let mapZoom = component.map.getZoom();
-        expect(mapCenter).toEqual(MAP_CONSTANTS.defaultCenter);
-        expect(mapZoom).toEqual(MAP_CONSTANTS.defaultZoom);
-    });
-
     it('mapFilterForm should be valid after toggleStateSelection', () => {
         let state = {
             counties: null,

--- a/src/app/map/map.component.spec.ts
+++ b/src/app/map/map.component.spec.ts
@@ -350,6 +350,17 @@ describe('MapComponent', () => {
         component.updateEventFilter();
     });
 
+    it('#siteFocus sets map to filtered sites extent', () => {
+        //zoom out beyond the default extent or extend of most recent event
+        let notDefaultCenter = new L.LatLng(55.8283, -125.5795);
+        component.map.setView(notDefaultCenter, 3);
+        //zoom back to filtered sites
+        component.siteFocus();
+        fixture.detectChanges();
+        //map should have zoomed in after clicking button
+        expect(component.map.getZoom()).toBeGreaterThan(3);
+    });
+
     it('mapFilterForm should be valid after toggleStateSelection', () => {
         let state = {
             counties: null,

--- a/src/app/map/map.component.spec.ts
+++ b/src/app/map/map.component.spec.ts
@@ -351,14 +351,17 @@ describe('MapComponent', () => {
     });
 
     it('#siteFocus sets map to filtered sites extent', () => {
-        //zoom out beyond the default extent or extend of most recent event
+        //zoom to sites or default zoom
+        component.siteFocus();
+        let mapZoom = component.map.getZoom();
+        //zoom to somewhere else
         let notDefaultCenter = new L.LatLng(55.8283, -125.5795);
         component.map.setView(notDefaultCenter, 3);
         //zoom back to filtered sites
         component.siteFocus();
         fixture.detectChanges();
-        //map should have zoomed in after clicking button
-        expect(component.map.getZoom()).toBeGreaterThan(3);
+        //map should have zoomed back to sites or default
+        expect(component.map.getZoom()).toEqual(mapZoom);
     });
 
     it('mapFilterForm should be valid after toggleStateSelection', () => {

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -822,7 +822,12 @@ export class MapComponent implements OnInit {
             this.map.fitBounds(
                 this.siteService.manyFilteredSitesMarkers.getBounds()
             );
-        } else {
+        } else if (
+            this.map.hasLayer(
+                this.siteService.manyFilteredSitesMarkers === false &&
+                    this.map.hasLayer(this.siteService.siteMarkers) === false
+            )
+        ) {
             this.map.setView(
                 MAP_CONSTANTS.defaultCenter,
                 MAP_CONSTANTS.defaultZoom

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -1015,13 +1015,17 @@ export class MapComponent implements OnInit {
         this.selectedStates = new Array<State>();
         // this works but will not fully clear mat-selects if they're open when the box is clicked
         this.mapFilterForm.reset();
+
         //remove markers and zoom to U.S.
         this.resultsReturned = false;
         this.resetPreviousOutput();
         this.siteFocus();
+
         // clear and close results table
         this.filtersService.updateSites([]);
-        this.filterResultsComponent.refreshDataSource();
+        if (this.filterResultsComponent !== undefined) {
+            this.filterResultsComponent.refreshDataSource();
+        }
         this.filtersService.changeResultsPanelState(false);
         this.resultsPanelSubscription = this.filtersService.resultsPanelOpen.subscribe(
             (state) => (this.resultsPanelState = state)

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -1019,6 +1019,15 @@ export class MapComponent implements OnInit {
         this.resultsReturned = false;
         this.resetPreviousOutput();
         this.siteFocus();
+        // clear and close results table
+        this.filtersService.updateSites([]);
+        this.filterResultsComponent.refreshDataSource();
+        this.filtersService.changeResultsPanelState(false);
+        this.resultsPanelSubscription = this.filtersService.resultsPanelOpen.subscribe(
+            (state) => (this.resultsPanelState = state)
+        );
+        //keep filters panel open
+        this.filtersPanelState = true;
     }
 
     public submitMapFilter() {

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -174,7 +174,7 @@ export class MapComponent implements OnInit {
             ' wmm-pin wmm-altblue wmm-icon-circle wmm-icon-white wmm-size-20',
     });
     //for the All STN Sites layer
-    siteIcon = L.divIcon({
+    allSiteIcon = L.divIcon({
         className: ' allSiteIcon ',
         iconSize: 32,
     });
@@ -372,7 +372,7 @@ export class MapComponent implements OnInit {
             this.resultsReturned = true;
             this.mapResults(
                 this.allSites,
-                this.siteIcon,
+                this.allSiteIcon,
                 this.siteService.allSiteMarkers,
                 false
             );
@@ -812,7 +812,6 @@ export class MapComponent implements OnInit {
     }
 
     siteFocus() {
-        console.log('hit siteFocus');
         //If there are site markers, zoom to those
         //Otherwise, zoom back to default extent
         if (this.map.hasLayer(this.siteService.siteMarkers)) {
@@ -1152,6 +1151,7 @@ export class MapComponent implements OnInit {
                                     }
                                 }
                                 this.currentQuery += 1;
+                                //map results after network is complete
                                 if (this.currentQuery === this.totalQueries) {
                                     this.getFilterResults(uniqueSites);
                                 }

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -812,21 +812,21 @@ export class MapComponent implements OnInit {
     }
 
     siteFocus() {
+        let siteMarkersOnMap = this.map.hasLayer(this.siteService.siteMarkers);
+        let manySiteMarkersOnMap = this.map.hasLayer(
+            this.siteService.manyFilteredSitesMarkers
+        );
         //If there are site markers, zoom to those
         //Otherwise, zoom back to default extent
-        if (this.map.hasLayer(this.siteService.siteMarkers)) {
+        if (siteMarkersOnMap) {
             this.map.fitBounds(this.siteService.siteMarkers.getBounds());
-        } else if (
-            this.map.hasLayer(this.siteService.manyFilteredSitesMarkers)
-        ) {
+        } else if (manySiteMarkersOnMap) {
             this.map.fitBounds(
                 this.siteService.manyFilteredSitesMarkers.getBounds()
             );
         } else if (
-            this.map.hasLayer(
-                this.siteService.manyFilteredSitesMarkers === false &&
-                    this.map.hasLayer(this.siteService.siteMarkers) === false
-            )
+            siteMarkersOnMap === false &&
+            manySiteMarkersOnMap === false
         ) {
             this.map.setView(
                 MAP_CONSTANTS.defaultCenter,
@@ -1012,6 +1012,10 @@ export class MapComponent implements OnInit {
         this.selectedStates = new Array<State>();
         // this works but will not fully clear mat-selects if they're open when the box is clicked
         this.mapFilterForm.reset();
+        //remove markers and zoom to U.S.
+        this.resultsReturned = false;
+        this.resetPreviousOutput();
+        this.siteFocus();
     }
 
     public submitMapFilter() {

--- a/src/app/services/filters.service.ts
+++ b/src/app/services/filters.service.ts
@@ -12,10 +12,16 @@ import 'leaflet';
     providedIn: 'root',
 })
 export class FiltersService {
+    private resultsPanelState = new BehaviorSubject(false);
+    public resultsPanelOpen = this.resultsPanelState.asObservable();
     constructor() {}
 
     private filteredSites = new BehaviorSubject<any>([]);
     selectedSites = this.filteredSites.asObservable();
+
+    changeResultsPanelState(state: boolean) {
+        this.resultsPanelState.next(state);
+    }
 
     updateSites(sites: any) {
         this.filteredSites.next(sites);

--- a/src/app/services/site.service.ts
+++ b/src/app/services/site.service.ts
@@ -83,7 +83,7 @@ export class SiteService {
 
     public manyFilteredSitesMarkers = new L.markerClusterGroup({
         showCoverageOnHover: false,
-        maxClusterRadius: 40,
+        maxClusterRadius: 25,
         iconCreateFunction: function (cluster) {
             var markers = cluster.getAllChildMarkers();
             var html =


### PR DESCRIPTION
- clears markers when click 'clear filters'
- opens results panel when filter is run
I pulled from 173 to avoid merge conflicts, so combining these two issues here. 