### PR TITLE
fix clear filters bug to reset event list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 -   Width of map container on mobile fits to screen size
+-   Event list is reset when "Clear Filters" is clicked and active styling for previously selected event types removed
 
 ## [v0.5.0](https://github.com/USGS-WiM/stnweb2/releases/tag/v0.5.0) - 2021-06-10
 

--- a/src/app/filter/filter.component.html
+++ b/src/app/filter/filter.component.html
@@ -13,6 +13,7 @@
                     >Filter Events by Type</mat-label
                 >
                 <mat-select
+                    #eventTypeOptions
                     id="eventTypeOptions"
                     formControlName="eventTypeControl"
                     (selectionChange)="onEventChange()"

--- a/src/app/filter/filter.component.spec.ts
+++ b/src/app/filter/filter.component.spec.ts
@@ -8,6 +8,11 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
 import { FilterComponent } from './filter.component';
 import { Event } from '@interfaces/event';
+import { MatOptionModule } from '@angular/material/core';
+import { MatSelectModule } from '@angular/material/select';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('FilterComponent', () => {
   let component: FilterComponent;
@@ -19,7 +24,12 @@ describe('FilterComponent', () => {
       imports: [
         HttpClientTestingModule,
         HttpClientTestingModule,
-        MatAutocompleteModule
+        MatAutocompleteModule,
+        MatOptionModule,
+        MatSelectModule,
+        MatFormFieldModule,
+        MatInputModule,
+        NoopAnimationsModule,
     ], schemas: [CUSTOM_ELEMENTS_SCHEMA],
     })
     .compileComponents();
@@ -77,6 +87,12 @@ describe('FilterComponent', () => {
     component.onClear();
     fixture.detectChanges();
     expect(component.clearMapFilterForm.emit).toHaveBeenCalled();
+  });
+
+  it("should remove active styling on previously selected event types", () => {
+    component.onClear();
+    fixture.detectChanges();
+    expect(component.eventTypeOptions.options.forEach((option) => option.active)).toBeFalsy();
   });
 
   it("should emit on event filter change", () => {

--- a/src/app/filter/filter.component.ts
+++ b/src/app/filter/filter.component.ts
@@ -7,6 +7,8 @@ import { NetworkName } from '@interfaces/network-name';
 import { SensorType } from '@interfaces/sensor-type';
 import { SensorTypeService } from '@app/services/sensor-type.service';
 import { NetworkNameService } from '@app/services/network-name.service';
+import { MatSelect } from '@angular/material/select';
+import { MatOption } from '@angular/material/core';
 
 @Component({
     selector: 'app-filter',
@@ -14,6 +16,8 @@ import { NetworkNameService } from '@app/services/network-name.service';
     styleUrls: ['./filter.component.scss'],
 })
 export class FilterComponent implements OnInit {
+    @ViewChild('eventTypeOptions') eventTypeOptions: MatSelect;
+
     @Input('mapFilterForm') mapFilterForm: Object;
     @Input('states') states: State[] = [];
     @Input('filteredEvents$') filteredEvents$: Observable<Event[]>;
@@ -72,6 +76,9 @@ export class FilterComponent implements OnInit {
 
     // Call parent function when Clear Filters is clicked
     onClear(){
+        // remove active styling on previous selected options
+        this.eventTypeOptions.options.forEach((option: MatOption) => option.setInactiveStyles());
+        
         this.clearMapFilterForm.emit();
     }
 

--- a/src/app/map/map.component.spec.ts
+++ b/src/app/map/map.component.spec.ts
@@ -379,6 +379,8 @@ describe('MapComponent', () => {
     it('#clearMapFilterForm resets the filter form', () => {
         component.clearMapFilterForm();
         let formValues = component.mapFilterForm.value;
+        expect(formValues.eventTypeControl).toBeFalsy();
+        expect(formValues.eventStateControl).toBeFalsy();
         expect(formValues.eventsControl).toBeFalsy();
         expect(formValues.networkControl).toBeFalsy();
         expect(formValues.sensorControl).toBeFalsy();

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -1197,11 +1197,15 @@ export class MapComponent implements OnInit {
     }
 
     public clearMapFilterForm(): void {
-        //reset the event options
-        this.updateEventFilter();
         this.selectedStates = new Array<State>();
         this.mapFilterForm.get('stateControl').setValue(this.selectedStates);
         this.mapFilterForm.get('stateInput').setValue([null]);
+        this.mapFilterForm.get('eventStateControl').setValue(null);
+        this.mapFilterForm.get('eventTypeControl').setValue(null);
+
+        //reset the event options
+        this.updateEventFilter();
+
         // this works but will not fully clear mat-selects if they're open when the box is clicked
         this.mapFilterForm.reset();
 


### PR DESCRIPTION
* Event list resets when Clear Filters button is clicked
* Active styling is removed from previously selected event types in the event type dropdown