### PR TITLE
fix sidebar overlap with results table and footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 -   Map filters placed in sidebar component
+-   Clear Filters and Filter Sites buttons moved back from filter to map component
 
 ### Fixed
 
 -   Width of map container on mobile fits to screen size
 -   Event list is reset when "Clear Filters" is clicked and active styling for previously selected event types removed
+-   Fixed map filter overlap with results panel and footer
 
 ## [v0.5.0](https://github.com/USGS-WiM/stnweb2/releases/tag/v0.5.0) - 2021-06-10
 

--- a/src/app/filter/filter.component.html
+++ b/src/app/filter/filter.component.html
@@ -301,29 +301,6 @@
         </div>
     </mat-expansion-panel>
     </mat-accordion>
-
-    <div class="button-row">
-        <button
-            mat-raised-button
-            color="accent"
-            type="submit"
-            aria-label="Filter Sites"
-            (click)="onSubmit()"
-        >
-            <mat-icon>filter_alt</mat-icon>&nbsp;Filter
-            Sites
-        </button>
-        <button
-            mat-raised-button
-            color="warn"
-            type="reset"
-            aria-label="Clear filters"
-            (click)="onClear()"
-        >
-            <mat-icon>clear_all</mat-icon>&nbsp;Clear
-            Filters
-        </button>
-    </div>
 </form>
 
 

--- a/src/app/filter/filter.component.scss
+++ b/src/app/filter/filter.component.scss
@@ -14,14 +14,6 @@ $borderRadius: 4px;
 // Structure.scss
 // Scaffolding and flex styles for basic structure of page
 
-.button-row {
-    display: flex;
-    justify-content: center;
-}
-.mat-button-base {
-    margin: 8px 8px 8px 0;
-}
-
 .form-container .mat-form-field + .mat-form-field {
     margin-left: 8px;
 }

--- a/src/app/filter/filter.component.spec.ts
+++ b/src/app/filter/filter.component.spec.ts
@@ -8,11 +8,6 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 
 import { FilterComponent } from './filter.component';
 import { Event } from '@interfaces/event';
-import { MatOptionModule } from '@angular/material/core';
-import { MatSelectModule } from '@angular/material/select';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('FilterComponent', () => {
   let component: FilterComponent;
@@ -25,11 +20,6 @@ describe('FilterComponent', () => {
         HttpClientTestingModule,
         HttpClientTestingModule,
         MatAutocompleteModule,
-        MatOptionModule,
-        MatSelectModule,
-        MatFormFieldModule,
-        MatInputModule,
-        NoopAnimationsModule,
     ], schemas: [CUSTOM_ELEMENTS_SCHEMA],
     })
     .compileComponents();
@@ -71,28 +61,6 @@ describe('FilterComponent', () => {
         hwms: [],
     };
     expect(component.displayEvent(event)).toBe('Sandy');
-  });
-
-  it("should emit on submit", () => {
-    spyOn(component.submitMapFilter, 'emit');
-
-    component.onSubmit();
-    fixture.detectChanges();
-    expect(component.submitMapFilter.emit).toHaveBeenCalled();
-  });
-
-  it("should emit on clear", () => {
-    spyOn(component.clearMapFilterForm, 'emit');
-
-    component.onClear();
-    fixture.detectChanges();
-    expect(component.clearMapFilterForm.emit).toHaveBeenCalled();
-  });
-
-  it("should remove active styling on previously selected event types", () => {
-    component.onClear();
-    fixture.detectChanges();
-    expect(component.eventTypeOptions.options.forEach((option) => option.active)).toBeFalsy();
   });
 
   it("should emit on event filter change", () => {

--- a/src/app/filter/filter.component.ts
+++ b/src/app/filter/filter.component.ts
@@ -8,7 +8,6 @@ import { SensorType } from '@interfaces/sensor-type';
 import { SensorTypeService } from '@app/services/sensor-type.service';
 import { NetworkNameService } from '@app/services/network-name.service';
 import { MatSelect } from '@angular/material/select';
-import { MatOption } from '@angular/material/core';
 
 @Component({
     selector: 'app-filter',
@@ -59,27 +58,6 @@ export class FilterComponent implements OnInit {
     // Update event list when filters are changed
     onEventChange(){
         this.updateEventFilter.emit();
-    }
-
-    // Call parent function when Submit is clicked
-    onSubmit(){
-        this.submitMapFilter.emit();
-
-        // Close map filters when submitted
-        this.eventPanelState = false;
-        this.networksPanelState = false;
-        this.sensorPanelState = false;
-        this.statesPanelState = false;
-        this.hmwPanelState = false;
-        this.additionalFiltersPanelState = false;
-    }
-
-    // Call parent function when Clear Filters is clicked
-    onClear(){
-        // remove active styling on previous selected options
-        this.eventTypeOptions.options.forEach((option: MatOption) => option.setInactiveStyles());
-        
-        this.clearMapFilterForm.emit();
     }
 
     // options to be displayed when selecting event filter

--- a/src/app/map/map.component.html
+++ b/src/app/map/map.component.html
@@ -217,23 +217,47 @@
         <!-- Filter/Results -->
         <mat-card id="filtersSection">
             <mat-card-content (window:resize)="onResize()" [ngStyle]="{'display': !isMobile ? 'block' : (isClicked ? 'block' : (firstLoaded ? 'none' : (!isSubmitted ? 'block' : 'none' )))}" >
-                <app-filter
-                    [mapFilterForm]="mapFilterForm"
-                    [states]="states"
-                    [filteredEvents$]="filteredEvents$"
-                    [filteredStates$]="filteredStates$"
-                    [selectedStates]="selectedStates"
-                    [eventStates$]="eventStates$"
-                    [eventTypes$]="eventTypes$"
-                    (updateEventFilter)="updateEventFilter()"
-                    (submitMapFilter)="submitMapFilter()"
-                    (clearMapFilterForm)="clearMapFilterForm()"
-                    (selectState)="selectState($event)"
-                    (remove)="remove($event)"
-                    (addState)="addState($event)"
-                    (displayMostRecentEvent)="displayMostRecentEvent()"
-                    (getEventList)="getEventList()"
-                ></app-filter>
+                <div id="mapFilters">
+                    <app-filter
+                        [mapFilterForm]="mapFilterForm"
+                        [states]="states"
+                        [filteredEvents$]="filteredEvents$"
+                        [filteredStates$]="filteredStates$"
+                        [selectedStates]="selectedStates"
+                        [eventStates$]="eventStates$"
+                        [eventTypes$]="eventTypes$"
+                        (updateEventFilter)="updateEventFilter()"
+                        (submitMapFilter)="submitMapFilter()"
+                        (clearMapFilterForm)="clearMapFilterForm()"
+                        (selectState)="selectState($event)"
+                        (remove)="remove($event)"
+                        (addState)="addState($event)"
+                        (displayMostRecentEvent)="displayMostRecentEvent()"
+                        (getEventList)="getEventList()"
+                    ></app-filter>
+                </div>
+                <div class="button-row">
+                    <button
+                        mat-raised-button
+                        color="accent"
+                        type="submit"
+                        aria-label="Filter Sites"
+                        (click)="submitMapFilter()"
+                    >
+                        <mat-icon>filter_alt</mat-icon>&nbsp;Filter
+                        Sites
+                    </button>
+                    <button
+                        mat-raised-button
+                        color="warn"
+                        type="reset"
+                        aria-label="Clear filters"
+                        (click)="clearMapFilterForm()"
+                    >
+                        <mat-icon>clear_all</mat-icon>&nbsp;Clear
+                        Filters
+                    </button>
+                </div>
             </mat-card-content>
             <app-filter-results [ngStyle]="{'display': isClicked ? 'none' : (firstLoaded ? 'block' : (isSubmitted ? 'block' : 'none'))}"
                     [mapFilterForm]="mapFilterForm"

--- a/src/app/map/map.component.scss
+++ b/src/app/map/map.component.scss
@@ -409,12 +409,27 @@ $borderRadius: 4px;
     .mat-card-content {
         width: 28%;
         max-width: 28%;
-        margin: 15px;
+        margin-left: 15px;
         height: 70vh;
+        min-height: 375px;
+        margin-bottom: 20px;
+    }
+    #mapFilters{
+        overflow-y: auto;
+        max-height: 65vh;
     }
 
     .mat-expansion-panel {
         margin-bottom: 15px;
+    }
+
+    .button-row {
+        display: flex;
+        justify-content: center;
+    }
+
+    .mat-button-base {
+        margin: 8px 8px 8px 0;
     }
 }
 

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -62,6 +62,8 @@ import { EventType } from '@app/interfaces/event-type';
 import { Subject } from 'rx';
 import { canvas } from 'leaflet';
 import { FilterResultsComponent } from '@app/filter-results/filter-results.component';
+import { FilterComponent } from '@app/filter/filter.component';
+import { MatOption } from '@angular/material/core';
 
 @Component({
     selector: 'app-map',
@@ -71,6 +73,9 @@ import { FilterResultsComponent } from '@app/filter-results/filter-results.compo
 export class MapComponent implements OnInit {
     @ViewChild(FilterResultsComponent)
     filterResultsComponent: FilterResultsComponent;
+
+    @ViewChild(FilterComponent)
+    filterComponent: FilterComponent;
 
     public addOnBlur = true;
     public filteredStates$: Observable<State[]>;
@@ -1197,6 +1202,10 @@ export class MapComponent implements OnInit {
     }
 
     public clearMapFilterForm(): void {
+        // remove active styling on previous selected options
+        if (this.filterComponent !== undefined) {
+            this.filterComponent.eventTypeOptions.options.forEach((option: MatOption) => option.setInactiveStyles());
+        }
         this.selectedStates = new Array<State>();
         this.mapFilterForm.get('stateControl').setValue(this.selectedStates);
         this.mapFilterForm.get('stateInput').setValue([null]);
@@ -1241,6 +1250,17 @@ export class MapComponent implements OnInit {
     }
 
     public submitMapFilter() {
+
+        // Close map filters when submitted
+        if (this.filterComponent !== undefined) {
+            this.filterComponent.eventPanelState = false;
+            this.filterComponent.networksPanelState = false;
+            this.filterComponent.sensorPanelState = false;
+            this.filterComponent.statesPanelState = false;
+            this.filterComponent.hmwPanelState = false;
+            this.filterComponent.additionalFiltersPanelState = false;
+        }
+
         //each time filter is clicked, reset status of results
         this.resultsReturned = false;
         this.currentQuery = 0;


### PR DESCRIPTION
* Fixed sidebar overlap on short screen sizes
* Made sidebar panel scrollable on small screen sizes (overflow-y: auto)
* Moved Filter Sites and Clear Filters buttons back to map component to fix their position at the bottom of the sidebar outside the scrollable area.