### PR TITLE
246 - site ID not populating when event filters changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -   Results and result modal mobile responsiveness
 -   Bug in consistently populating results table
 -   Streamgage markers removed from map when Clear Filters button is clicked
+-   Fixed site ID not added to popups for some sites
 
 ## [v0.5.0](https://github.com/USGS-WiM/stnweb2/releases/tag/v0.5.0) - 2021-06-10
 

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -1478,6 +1478,10 @@ export class MapComponent implements OnInit {
         this.siteService.allSiteMarkers.on('click', (e) => {
             this.addRouterLink(e);
         })
+
+        this.siteService.manyFilteredSitesMarkers.on('click', (e) => {
+            this.addRouterLink(e);
+        })
     }
 
     addRouterLink(e){


### PR DESCRIPTION
I forgot to add a call to the function populating the site ID/site page link for the manyFilteredSiteMarkers layer 🤦 