### PR TITLE
#254 switches prod url with test; removes extra / in members request

### DIFF
--- a/src/app/services/site.service.spec.ts
+++ b/src/app/services/site.service.spec.ts
@@ -257,7 +257,7 @@ describe('SiteService', () => {
             );
         });
         const req = httpTestingController.expectOne(
-            APP_SETTINGS.API_ROOT + '/Members/' + 5 + '.json'
+            APP_SETTINGS.API_ROOT + 'Members/' + 5 + '.json'
 
         );
         req.flush(mockMemberNameList);

--- a/src/app/services/site.service.ts
+++ b/src/app/services/site.service.ts
@@ -227,7 +227,7 @@ export class SiteService {
     //Get member name
     public getMemberName(member_id): Observable<any> {
         return this.httpClient
-            .get(APP_SETTINGS.API_ROOT + '/Members/' + member_id + '.json', {
+            .get(APP_SETTINGS.API_ROOT + 'Members/' + member_id + '.json', {
                 headers: APP_SETTINGS.AUTH_JSON_HEADERS,
             })
             .pipe(

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,12 +5,11 @@
 export const environment = {
     production: false,
     hmr: false,
-    api_root: 'https://stn.wim.usgs.gov/STNServices/', // add service endpoint once they're ready
+    api_root: 'https://stntest.wim.usgs.gov/stnservices/', // add service endpoint once they're ready
 };
 
 /*
  * For easier debugging in development mode, you can import the following file
- * to ignore zone related error stack frames such as `zone.run`, `zoneDelegate.invokeTask`.
  *
  * This import should be commented out in production mode because it will have a negative impact
  * on performance if an error is thrown.


### PR DESCRIPTION
I noticed there was a double slash on the members request because the api_root has the / already so I removed it. from the members service. It was actually working with the // lol but want to keep the code uniform