### PR TITLE
263 - add site edit dialog

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,7 +23,7 @@ import { MatTableModule } from '@angular/material/table';
 import { MatPaginatorModule } from '@angular/material/paginator';
 import { MatButtonModule } from '@angular/material/button';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
-import { MatOptionModule } from '@angular/material/core';
+import { MatNativeDateModule, MatOptionModule } from '@angular/material/core';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -36,6 +36,7 @@ import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatSortModule } from '@angular/material/sort';
+import { MatDatepickerModule } from '@angular/material/datepicker';
 
 import { HighchartsChartModule } from 'highcharts-angular';
 
@@ -67,6 +68,7 @@ import { PeakDialogComponent } from './peak-dialog/peak-dialog.component';
 import { FileDetailsDialogComponent } from './file-details-dialog/file-details-dialog.component';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { SiteEditComponent } from './site-edit/site-edit.component';
+import * as angular from 'angular';
 
 @NgModule({
     declarations: [
@@ -129,6 +131,8 @@ import { SiteEditComponent } from './site-edit/site-edit.component';
         MatProgressSpinnerModule,
         BrowserAnimationsModule,
         MatTooltipModule,
+        MatDatepickerModule,
+        MatNativeDateModule,
     ],
     providers: [
         CurrentUserService,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -65,6 +65,8 @@ import { HwmDialogComponent } from './hwm-dialog/hwm-dialog.component';
 import { SensorDialogComponent } from './sensor-dialog/sensor-dialog.component';
 import { PeakDialogComponent } from './peak-dialog/peak-dialog.component';
 import { FileDetailsDialogComponent } from './file-details-dialog/file-details-dialog.component';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { SiteEditComponent } from './site-edit/site-edit.component';
 
 @NgModule({
     declarations: [
@@ -87,6 +89,7 @@ import { FileDetailsDialogComponent } from './file-details-dialog/file-details-d
         SensorDialogComponent,
         PeakDialogComponent,
         FileDetailsDialogComponent,
+        SiteEditComponent,
     ],
     imports: [
         BrowserModule,
@@ -125,6 +128,7 @@ import { FileDetailsDialogComponent } from './file-details-dialog/file-details-d
         HighchartsChartModule,
         MatProgressSpinnerModule,
         BrowserAnimationsModule,
+        MatTooltipModule,
     ],
     providers: [
         CurrentUserService,

--- a/src/app/file-details-dialog/file-details-dialog.component.html
+++ b/src/app/file-details-dialog/file-details-dialog.component.html
@@ -97,7 +97,7 @@
             </div>
             <div class="cell-container" *ngIf="data.row_data.is_nwis === undefined || data.row_data.is_nwis !== 1">
                 <p class="content-left">Associated File</p>
-                <p class="content-right" *ngIf="data.row_data.name !== undefined && data.row_data.name !== ''; else nullAssociatedFile"><a id="associatedFile" href="#" target="_blank">{{data.row_data.name}}</a></p>
+                <p class="content-right" *ngIf="data.row_data.name !== undefined && data.row_data.name !== ''; else nullAssociatedFile"><a id="associatedFile" href="{{associatedFileUrl}}" target="_blank">{{data.row_data.name}}</a></p>
                 <ng-template #nullAssociatedFile><p class="content-right">---Missing---</p></ng-template>
             </div>
         </div>

--- a/src/app/file-details-dialog/file-details-dialog.component.html
+++ b/src/app/file-details-dialog/file-details-dialog.component.html
@@ -48,12 +48,12 @@
             </div>
             <div class="cell-container"  *ngIf="fileType === 'Photo'">
                 <p class="content-left">Photo Date</p>
-                <p class="content-right" *ngIf="data.row_data.photo_date !== undefined && data.row_data.photo_date !== ''; else nullPhotoDate">{{data.row_data.photo_date}}</p>
+                <p class="content-right" *ngIf="data.row_data.format_photo_date !== undefined && data.row_data.format_photo_date !== ''; else nullPhotoDate">{{data.row_data.format_photo_date}}</p>
                 <ng-template #nullPhotoDate><p class="content-right">---</p></ng-template>
             </div>
             <div class="cell-container">
                 <p class="content-left">Date Uploaded</p>
-                <p class="content-right" *ngIf="data.row_data.file_date !== undefined && data.row_data.file_date !== ''; else nullFileDate">{{data.row_data.file_date}}</p>
+                <p class="content-right" *ngIf="data.row_data.format_file_date !== undefined && data.row_data.format_file_date !== ''; else nullFileDate">{{data.row_data.format_file_date}}</p>
                 <ng-template #nullFileDate><p class="content-right">---</p></ng-template>
             </div>
             <div class="cell-container">

--- a/src/app/file-details-dialog/file-details-dialog.component.ts
+++ b/src/app/file-details-dialog/file-details-dialog.component.ts
@@ -35,7 +35,7 @@ export class FileDetailsDialogComponent implements OnInit {
         this.setSource();
       }
 
-      this.associatedFileUrl = APP_SETTINGS.API_ROOT + '/Files/' + this.data.row_data.file_id + '/Item';
+      this.associatedFileUrl = APP_SETTINGS.API_ROOT + 'Files/' + this.data.row_data.file_id + '/Item';
       let associatedFile = document.querySelector("#associatedFile");
       if(associatedFile !== null){
         associatedFile.setAttribute('href', this.associatedFileUrl);

--- a/src/app/services/site-edit.service.spec.ts
+++ b/src/app/services/site-edit.service.spec.ts
@@ -1,13 +1,28 @@
 import { TestBed } from '@angular/core/testing';
 
 import { SiteEditService } from './site-edit.service';
+import { HttpClient } from '@angular/common/http';
+import {
+    HttpClientTestingModule,
+    HttpTestingController,
+} from '@angular/common/http/testing';
 
 describe('SiteEditService', () => {
   let service: SiteEditService;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [SiteEditService, HttpClient],
+      imports: [HttpClientTestingModule],
+    });
+    httpTestingController = TestBed.inject(HttpTestingController);
     service = TestBed.inject(SiteEditService);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
+    TestBed.resetTestingModule();
   });
 
   it('should be created', () => {

--- a/src/app/services/site-edit.service.spec.ts
+++ b/src/app/services/site-edit.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SiteEditService } from './site-edit.service';
+
+describe('SiteEditService', () => {
+  let service: SiteEditService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SiteEditService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/site-edit.service.spec.ts
+++ b/src/app/services/site-edit.service.spec.ts
@@ -62,7 +62,7 @@ describe('SiteEditService', () => {
         );
     });
     const req = httpTestingController.expectOne(
-      APP_SETTINGS.SITES_URL + '/LandOwners/9999.json',
+      APP_SETTINGS.API_ROOT + 'LandOwners/9999.json',
     );
     req.flush(mockLandowner);
   });

--- a/src/app/services/site-edit.service.spec.ts
+++ b/src/app/services/site-edit.service.spec.ts
@@ -6,6 +6,7 @@ import {
     HttpClientTestingModule,
     HttpTestingController,
 } from '@angular/common/http/testing';
+import { APP_SETTINGS } from '@app/app.settings';
 
 describe('SiteEditService', () => {
   let service: SiteEditService;
@@ -28,4 +29,273 @@ describe('SiteEditService', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  it('#putSite() should update single site', () => {
+      let mockSite = 
+          {
+              site_id: 24224,
+          }
+
+      service.putSite('24224', mockSite).subscribe((results) => {
+          expect(results).not.toBe(null);
+          expect(JSON.stringify(results)).toEqual(
+              JSON.stringify(mockSite)
+          );
+      });
+      const req = httpTestingController.expectOne(
+        APP_SETTINGS.SITES_URL + '/24224.json',
+      );
+      req.flush(mockSite);
+  });
+
+  it('#putLandowner() should update a site landowner contact', () => {
+    let mockLandowner = 
+        {
+            site_id: 24224,
+            landownercontact_id: 9999,
+        }
+
+    service.putLandowner(mockLandowner.landownercontact_id, mockLandowner).subscribe((results) => {
+        expect(results).not.toBe(null);
+        expect(JSON.stringify(results)).toEqual(
+            JSON.stringify(mockLandowner)
+        );
+    });
+    const req = httpTestingController.expectOne(
+      APP_SETTINGS.SITES_URL + '/LandOwners/9999.json',
+    );
+    req.flush(mockLandowner);
+  });
+
+  it('#postLandowner() should create a new landowner', () => {
+    let mockLandowner = 
+        {
+            site_id: 24224,
+            fname: "test"
+        }
+
+    service.postLandowner(mockLandowner).subscribe((results) => {
+        expect(results).not.toBe(null);
+        expect(JSON.stringify(results)).toEqual(
+            JSON.stringify(mockLandowner)
+        );
+    });
+    const req = httpTestingController.expectOne(
+      APP_SETTINGS.API_ROOT + 'LandOwners.json',
+    );
+    req.flush(mockLandowner);
+  });
+
+  it('#postNetworkNames() should add a network name to a site', () => {
+    let mockNetworkName = 
+        {
+            network_name_id: 1,
+        }
+
+    service.postNetworkNames('24224', mockNetworkName.network_name_id).subscribe((results) => {
+        expect(results).not.toBe(null);
+        expect(JSON.stringify(results)).toEqual(
+            JSON.stringify(mockNetworkName)
+        );
+    });
+    const req = httpTestingController.expectOne(
+      APP_SETTINGS.API_ROOT + 'sites/24224/AddNetworkName?NetworkNameId=1',
+    );
+    req.flush(mockNetworkName);
+  });
+
+  it('#deleteNetworkNames() should remove a network name from a site', () => {
+    let mockNetworkName = [];
+
+    service.deleteNetworkNames('24224', 1).subscribe((results) => {
+        expect(results).not.toBe(null);
+        expect(JSON.stringify(results)).toEqual(
+            JSON.stringify(mockNetworkName)
+        );
+    });
+    const req = httpTestingController.expectOne(
+      APP_SETTINGS.SITES_URL + '/24224/removeNetworkName?NetworkNameId=1',
+    );
+    req.flush(mockNetworkName);
+  });
+
+  it('#postNetworkTypes() should add a network type to a site', () => {
+    let mockNetworkType = 
+        {
+            network_type_id: 1,
+        }
+
+    service.postNetworkTypes('24224', mockNetworkType.network_type_id).subscribe((results) => {
+        expect(results).not.toBe(null);
+        expect(JSON.stringify(results)).toEqual(
+            JSON.stringify(mockNetworkType)
+        );
+    });
+    const req = httpTestingController.expectOne(
+      APP_SETTINGS.API_ROOT + 'sites/24224/AddNetworkType?NetworkTypeId=1',
+    );
+    req.flush(mockNetworkType);
+  });
+
+  it('#deleteNetworkTypes() should remove a network type from a site', () => {
+    let mockNetworkType = [];
+
+    service.deleteNetworkTypes('24224', 1).subscribe((results) => {
+        expect(results).not.toBe(null);
+        expect(JSON.stringify(results)).toEqual(
+            JSON.stringify(mockNetworkType)
+        );
+    });
+    const req = httpTestingController.expectOne(
+      APP_SETTINGS.API_ROOT + 'sites/24224/removeNetworkType?NetworkTypeId=1'
+    );
+    req.flush(mockNetworkType);
+  });
+
+  it('#deleteSiteHousings() should remove a site housing from a site', () => {
+    let mockSiteHousing = [];
+
+    service.deleteSiteHousings('10').subscribe((results) => {
+        expect(results).not.toBe(null);
+        expect(JSON.stringify(results)).toEqual(
+            JSON.stringify(mockSiteHousing)
+        );
+    });
+    const req = httpTestingController.expectOne(
+      APP_SETTINGS.API_ROOT + 'SiteHousings/10.json',
+    );
+    req.flush(mockSiteHousing);
+  });
+
+  it('#postSiteHousings() should add a site housing to a site', () => {
+    let mockSiteHousing = 
+        {
+            housing_type_id: 10,
+            site_id: 24224,
+        }
+
+    service.postSiteHousings(mockSiteHousing).subscribe((results) => {
+        expect(results).not.toBe(null);
+        expect(JSON.stringify(results)).toEqual(
+            JSON.stringify(mockSiteHousing)
+        );
+    });
+    const req = httpTestingController.expectOne(
+      APP_SETTINGS.API_ROOT + 'SiteHousings.json',
+    );
+    req.flush(mockSiteHousing);
+  });
+
+  it('#putSiteHousings() should edit a site housing for a site', () => {
+    let mockSiteHousing = 
+        {
+            housing_type_id: 10,
+            site_id: 24224,
+            amount: 1,
+        }
+
+    service.putSiteHousings(mockSiteHousing.housing_type_id, mockSiteHousing).subscribe((results) => {
+        expect(results).not.toBe(null);
+        expect(JSON.stringify(results)).toEqual(
+            JSON.stringify(mockSiteHousing)
+        );
+    });
+    const req = httpTestingController.expectOne(
+      APP_SETTINGS.API_ROOT + 'SiteHousings/10.json',
+    );
+    req.flush(mockSiteHousing);
+  });
+
+  it('#postSource() should add a source or return an existing source', () => {
+    let mockSource = 
+        {
+            source_id: 9999,
+            source_name: "test"
+        }
+
+    service.postSource(mockSource).subscribe((results) => {
+        expect(results).not.toBe(null);
+        expect(JSON.stringify(results)).toEqual(
+            JSON.stringify(mockSource)
+        );
+    });
+    const req = httpTestingController.expectOne(
+      APP_SETTINGS.API_ROOT + '/Sources.json',
+    );
+    req.flush(mockSource);
+  });
+
+  it('#uploadFile() should add a new file', () => {
+    let mockFile = 
+        {
+            filetype_id: 1,
+            name: "test file"
+        }
+
+    service.uploadFile(mockFile).subscribe((results) => {
+        expect(results).not.toBe(null);
+        expect(JSON.stringify(results)).toEqual(
+            JSON.stringify(mockFile)
+        );
+    });
+    const req = httpTestingController.expectOne(
+      APP_SETTINGS.API_ROOT + 'Files/bytes',
+    );
+    req.flush(mockFile);
+  });
+
+  it('#saveFile() should create a new link file', () => {
+    let mockFile = 
+        {
+            filetype_id: 1,
+            name: "test file"
+        }
+
+    service.saveFile(mockFile).subscribe((results) => {
+        expect(results).not.toBe(null);
+        expect(JSON.stringify(results)).toEqual(
+            JSON.stringify(mockFile)
+        );
+    });
+    const req = httpTestingController.expectOne(
+      APP_SETTINGS.API_ROOT + 'Files.json',
+    );
+    req.flush(mockFile);
+  });
+
+  it('#updateFile() should add edit or add file attributes to an existing file', () => {
+    let mockFile = 
+        {
+            file_id: 9999,
+            filetype_id: 1,
+            name: "test"
+        }
+
+    service.updateFile(mockFile).subscribe((results) => {
+        expect(results).not.toBe(null);
+        expect(JSON.stringify(results)).toEqual(
+            JSON.stringify(mockFile)
+        );
+    });
+    const req = httpTestingController.expectOne(
+      APP_SETTINGS.API_ROOT + 'Files/9999.json',
+    );
+    req.flush(mockFile);
+  });
+
+  it('#deleteFile() should remove a file', () => {
+    let mockFile = [];
+
+    service.deleteFile(9999).subscribe((results) => {
+        expect(results).not.toBe(null);
+        expect(JSON.stringify(results)).toEqual(
+            JSON.stringify(mockFile)
+        );
+    });
+    const req = httpTestingController.expectOne(
+      APP_SETTINGS.API_ROOT + 'Files/9999.json',
+    );
+    req.flush(mockFile);
+  });
+
 });

--- a/src/app/services/site-edit.service.ts
+++ b/src/app/services/site-edit.service.ts
@@ -55,7 +55,7 @@ export class SiteEditService {
   public postLandowner(landowner): Observable<any> {
     // rootURL + '/LandOwners/:id.json'
     return this.httpClient
-        .post(APP_SETTINGS.API_ROOT + '/LandOwners.json',  landowner, {
+        .post(APP_SETTINGS.API_ROOT + 'LandOwners.json',  landowner, {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
       })
         .pipe(
@@ -145,7 +145,7 @@ export class SiteEditService {
   public deleteSiteHousings(siteHousingID): Observable<any> {
     // rootURL + '/SiteHousings/:id.json'
     return this.httpClient
-        .delete(APP_SETTINGS.API_ROOT + '/SiteHousings/' + siteHousingID + '.json',  {
+        .delete(APP_SETTINGS.API_ROOT + 'SiteHousings/' + siteHousingID + '.json',  {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
       })
         .pipe(
@@ -163,7 +163,7 @@ export class SiteEditService {
   public postSiteHousings(housing): Observable<any> {
     // rootURL + '/SiteHousings/:id.json'
     return this.httpClient
-        .post(APP_SETTINGS.API_ROOT + 'SiteHousings/' + housing.site_housing_id + '.json', housing, {
+        .post(APP_SETTINGS.API_ROOT + 'SiteHousings.json', housing, {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
       })
         .pipe(
@@ -181,7 +181,7 @@ export class SiteEditService {
   public putSiteHousings(siteHousingID, siteHousing): Observable<any> {
     // rootURL + '/SiteHousings/:id.json'
     return this.httpClient
-        .put(APP_SETTINGS.API_ROOT + '/SiteHousings/' + siteHousingID + '.json', siteHousing, {
+        .put(APP_SETTINGS.API_ROOT + 'SiteHousings/' + siteHousingID + '.json', siteHousing, {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
       })
         .pipe(
@@ -196,10 +196,10 @@ export class SiteEditService {
         );
   }
 
-  public postSource(sourceID, source): Observable<any> {
+  public postSource(source): Observable<any> {
     // rootURL + '/Sources/:id.json'
     return this.httpClient
-        .post(APP_SETTINGS.SITES_URL + '/Sources/' + sourceID + '.json',  source, {
+        .post(APP_SETTINGS.API_ROOT + '/Sources.json', source, {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
       })
         .pipe(
@@ -214,23 +214,22 @@ export class SiteEditService {
         );
   }
   
-  public uploadFile(sourceID, file): Observable<any> {
+  public uploadFile(file): Observable<any> {
   // uploadFile: { method: 'POST', url: rootURL + '/Files/bytes', headers: { 'Content-Type': undefined }, transformRequest: angular.identity, cache: false, isArray: false },
-    // return this.httpClient
-    //     .post(APP_SETTINGS.SITES_URL + 'Files/bytes',  file, {
-    //       headers: { 'Content-Type': undefined },
-    //   })
-    //     .pipe(
-    //         tap((response) => {
-    //             console.log(
-    //                 'uploadFile response received' //: ' +
-    //                 // JSON.stringify(response)
-    //             );
-    //             return response;
-    //         }),
-    //         catchError(this.handleError<any>('uploadFile', []))
-    //     );
-    return sourceID;
+    return this.httpClient
+        .post(APP_SETTINGS.API_ROOT + 'Files/bytes',  file, {
+          headers: { 'Content-Type': undefined },
+      })
+        .pipe(
+            tap((response) => {
+                console.log(
+                    'uploadFile response received' //: ' +
+                    // JSON.stringify(response)
+                );
+                return response;
+            }),
+            catchError(this.handleError<any>('uploadFile', []))
+        );
   }
 
   public deleteFile(sourceID, file): Observable<any> {

--- a/src/app/services/site-edit.service.ts
+++ b/src/app/services/site-edit.service.ts
@@ -35,21 +35,20 @@ export class SiteEditService {
   // Put landowner
   public putLandowner(landownerContactID, landowner): Observable<any> {
     // rootURL + '/LandOwners/:id.json'
-    // return this.httpClient
-    //     .put(APP_SETTINGS.SITES_URL + '/LandOwners/' + landownerContactID + '.json', landowner {
-    //       headers: APP_SETTINGS.AUTH_JSON_HEADERS,
-    //   })
-    //     .pipe(
-    //         tap((response) => {
-    //             console.log(
-    //                 'putLandowner response received' //: ' +
-    //                 // JSON.stringify(response)
-    //             );
-    //             return response;
-    //         }),
-    //         catchError(this.handleError<any>('putLandowner', []))
-    //     );
-    return landownerContactID;
+    return this.httpClient
+        .put(APP_SETTINGS.SITES_URL + '/LandOwners/' + landownerContactID + '.json', landowner, {
+          headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+      })
+        .pipe(
+            tap((response) => {
+                console.log(
+                    'putLandowner response received' //: ' +
+                    // JSON.stringify(response)
+                );
+                return response;
+            }),
+            catchError(this.handleError<any>('putLandowner', []))
+        );
   }
 
   public postLandowner(landowner): Observable<any> {
@@ -214,11 +213,10 @@ export class SiteEditService {
   }
   
   public uploadFile(file): Observable<any> {
-  // uploadFile: { method: 'POST', url: rootURL + '/Files/bytes', headers: { 'Content-Type': undefined }, transformRequest: angular.identity, cache: false, isArray: false },
     return this.httpClient
         .post(APP_SETTINGS.API_ROOT + 'Files/bytes',  file, {
-          headers: { 'Content-Type': undefined },
-      })
+            headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+        })
         .pipe(
             tap((response) => {
                 console.log(
@@ -233,7 +231,7 @@ export class SiteEditService {
 
   public saveFile(file): Observable<any> {
       return this.httpClient
-          .post(APP_SETTINGS.API_ROOT + 'Files.json',  file, {
+          .post(APP_SETTINGS.API_ROOT + 'Files.json', file, {
             headers: APP_SETTINGS.AUTH_JSON_HEADERS,
         })
           .pipe(
@@ -265,29 +263,22 @@ export class SiteEditService {
             );
       }
 
-  public deleteFile(sourceID, file): Observable<any> {
-    // uploadFile: { method: 'POST', url: rootURL + '/Files/bytes', headers: { 'Content-Type': undefined }, transformRequest: angular.identity, cache: false, isArray: false },
-      // return this.httpClient
-      //     .post(APP_SETTINGS.SITES_URL + 'Files/bytes',  file, {
-      //       headers: { 'Content-Type': undefined },
-      //   })
-      //     .pipe(
-      //         tap((response) => {
-      //             console.log(
-      //                 'uploadFile response received' //: ' +
-      //                 // JSON.stringify(response)
-      //             );
-      //             return response;
-      //         }),
-      //         catchError(this.handleError<any>('uploadFile', []))
-      //     );
-      return sourceID;
+  public deleteFile(fileID): Observable<any> {
+      return this.httpClient
+          .delete(APP_SETTINGS.API_ROOT + 'Files/' + fileID + '.json', {
+            headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+        })
+          .pipe(
+              tap((response) => {
+                  console.log(
+                      'deleteFile response received' //: ' +
+                      // JSON.stringify(response)
+                  );
+                  return response;
+              }),
+              catchError(this.handleError<any>('deleteFile', []))
+          );
     }
-
-  public fileStamp(): string {
-        let stamp = '?' + new Date().getTime();
-        return stamp;
-  }
 
   /**
      * Handle Http operation that failed.

--- a/src/app/services/site-edit.service.ts
+++ b/src/app/services/site-edit.service.ts
@@ -15,28 +15,28 @@ export class SiteEditService {
   }
 
   //Update single site by ID
-  public putSite(siteID: string): Observable<any> {
+  public putSite(siteID: string, site): Observable<any> {
     return this.httpClient
-        .put(APP_SETTINGS.SITES_URL + '/' + siteID + '.json',  {
+        .put(APP_SETTINGS.SITES_URL + '/' + siteID + '.json', site, {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
       })
         .pipe(
             tap((response) => {
                 console.log(
-                    'updateSingleSite response received' //: ' +
+                    'putSite response received' //: ' +
                     // JSON.stringify(response)
                 );
                 return response;
             }),
-            catchError(this.handleError<any>('updateSingleSite', []))
+            catchError(this.handleError<any>('putSite', []))
         );
   }
 
   // Put landowner
-  public putLandowner(landownerContactID): Observable<any> {
+  public putLandowner(landownerContactID, landowner): Observable<any> {
     // rootURL + '/LandOwners/:id.json'
     // return this.httpClient
-    //     .put(APP_SETTINGS.SITES_URL + '/LandOwners/' + landownerContactID + '.json',  {
+    //     .put(APP_SETTINGS.SITES_URL + '/LandOwners/' + landownerContactID + '.json', landowner {
     //       headers: APP_SETTINGS.AUTH_JSON_HEADERS,
     //   })
     //     .pipe(
@@ -52,10 +52,10 @@ export class SiteEditService {
     return landownerContactID;
   }
 
-  public postLandowner(landownerContactID): Observable<any> {
+  public postLandowner(landowner): Observable<any> {
     // rootURL + '/LandOwners/:id.json'
     return this.httpClient
-        .post(APP_SETTINGS.SITES_URL + '/LandOwners/' + landownerContactID + '.json',  {
+        .post(APP_SETTINGS.API_ROOT + '/LandOwners.json',  landowner, {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
       })
         .pipe(
@@ -73,9 +73,8 @@ export class SiteEditService {
   public postNetworkNames(siteID, networkNameID): Observable<any> {
     // params: { siteId: '@siteId', NetworkNameId: '@networkNameId' }, isArray: true, url: rootURL + '/sites/:siteId/AddNetworkName'
     return this.httpClient
-        .post(APP_SETTINGS.SITES_URL + '/sites' + siteID + 'AddNetworkName',  {
+        .post(APP_SETTINGS.SITES_URL + '/' + siteID + '/AddNetworkName?NetworkNameId=' + networkNameID, {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
-          params: { siteId: siteID, NetworkNameId: networkNameID },
       })
         .pipe(
             tap((response) => {
@@ -92,7 +91,7 @@ export class SiteEditService {
   public deleteNetworkNames(siteID, networkNameID): Observable<any> {
     // url: rootURL + '/sites/:siteId/removeNetworkName?NetworkNameId=:networkNameId'
     return this.httpClient
-        .delete(APP_SETTINGS.SITES_URL + '/sites/' + siteID + '/removeNetworkName?NetworkNameId=' + networkNameID,  {
+        .delete(APP_SETTINGS.SITES_URL + '/' + siteID + '/removeNetworkName?NetworkNameId=' + networkNameID,  {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
       })
         .pipe(
@@ -110,9 +109,8 @@ export class SiteEditService {
   public postNetworkTypes(siteID, networkTypeID): Observable<any> {
     // { siteId: '@siteId', NetworkTypeId: '@networkTypeId' }, isArray: true, url: rootURL + '/sites/:siteId/AddNetworkType'
     return this.httpClient
-        .post(APP_SETTINGS.SITES_URL + '/sites/' + siteID + '/AddNetworkType',  {
+        .post(APP_SETTINGS.SITES_URL + '/' + siteID + '/AddNetworkType?NetworkTypeId=' + networkTypeID, {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
-          params: { siteId: siteID, NetworkTypeId: networkTypeID },
       })
         .pipe(
             tap((response) => {
@@ -147,7 +145,7 @@ export class SiteEditService {
   public deleteSiteHousings(siteHousingID): Observable<any> {
     // rootURL + '/SiteHousings/:id.json'
     return this.httpClient
-        .delete(APP_SETTINGS.SITES_URL + '/SiteHousings/' + siteHousingID + '.json',  {
+        .delete(APP_SETTINGS.API_ROOT + '/SiteHousings/' + siteHousingID + '.json',  {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
       })
         .pipe(
@@ -162,10 +160,10 @@ export class SiteEditService {
         );
   }
 
-  public postSiteHousings(siteHousingID): Observable<any> {
+  public postSiteHousings(housing): Observable<any> {
     // rootURL + '/SiteHousings/:id.json'
     return this.httpClient
-        .post(APP_SETTINGS.SITES_URL + '/SiteHousings/' + siteHousingID + '.json',  {
+        .post(APP_SETTINGS.API_ROOT + 'SiteHousings/' + housing.site_housing_id + '.json', housing, {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
       })
         .pipe(
@@ -180,10 +178,10 @@ export class SiteEditService {
         );
   }
 
-  public putSiteHousings(siteHousingID): Observable<any> {
+  public putSiteHousings(siteHousingID, siteHousing): Observable<any> {
     // rootURL + '/SiteHousings/:id.json'
     return this.httpClient
-        .put(APP_SETTINGS.SITES_URL + '/SiteHousings/' + siteHousingID + '.json',  {
+        .put(APP_SETTINGS.API_ROOT + '/SiteHousings/' + siteHousingID + '.json', siteHousing, {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
       })
         .pipe(
@@ -198,10 +196,10 @@ export class SiteEditService {
         );
   }
 
-  public postSource(sourceID): Observable<any> {
+  public postSource(sourceID, source): Observable<any> {
     // rootURL + '/Sources/:id.json'
     return this.httpClient
-        .post(APP_SETTINGS.SITES_URL + '/Sources/' + sourceID + '.json',  {
+        .post(APP_SETTINGS.SITES_URL + '/Sources/' + sourceID + '.json',  source, {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
       })
         .pipe(
@@ -216,11 +214,11 @@ export class SiteEditService {
         );
   }
   
-  public uploadFile(sourceID): Observable<any> {
+  public uploadFile(sourceID, file): Observable<any> {
   // uploadFile: { method: 'POST', url: rootURL + '/Files/bytes', headers: { 'Content-Type': undefined }, transformRequest: angular.identity, cache: false, isArray: false },
     // return this.httpClient
-    //     .post(APP_SETTINGS.SITES_URL + 'Files/bytes',  {
-    //       headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+    //     .post(APP_SETTINGS.SITES_URL + 'Files/bytes',  file, {
+    //       headers: { 'Content-Type': undefined },
     //   })
     //     .pipe(
     //         tap((response) => {
@@ -233,6 +231,30 @@ export class SiteEditService {
     //         catchError(this.handleError<any>('uploadFile', []))
     //     );
     return sourceID;
+  }
+
+  public deleteFile(sourceID, file): Observable<any> {
+    // uploadFile: { method: 'POST', url: rootURL + '/Files/bytes', headers: { 'Content-Type': undefined }, transformRequest: angular.identity, cache: false, isArray: false },
+      // return this.httpClient
+      //     .post(APP_SETTINGS.SITES_URL + 'Files/bytes',  file, {
+      //       headers: { 'Content-Type': undefined },
+      //   })
+      //     .pipe(
+      //         tap((response) => {
+      //             console.log(
+      //                 'uploadFile response received' //: ' +
+      //                 // JSON.stringify(response)
+      //             );
+      //             return response;
+      //         }),
+      //         catchError(this.handleError<any>('uploadFile', []))
+      //     );
+      return sourceID;
+    }
+
+  public fileStamp(): string {
+        let stamp = '?' + new Date().getTime();
+        return stamp;
   }
 
   /**

--- a/src/app/services/site-edit.service.ts
+++ b/src/app/services/site-edit.service.ts
@@ -36,7 +36,7 @@ export class SiteEditService {
   public putLandowner(landownerContactID, landowner): Observable<any> {
     // rootURL + '/LandOwners/:id.json'
     return this.httpClient
-        .put(APP_SETTINGS.SITES_URL + '/LandOwners/' + landownerContactID + '.json', landowner, {
+        .put(APP_SETTINGS.API_ROOT + 'LandOwners/' + landownerContactID + '.json', landowner, {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
       })
         .pipe(

--- a/src/app/services/site-edit.service.ts
+++ b/src/app/services/site-edit.service.ts
@@ -33,6 +33,66 @@ export class SiteEditService {
         );
   }
 
+  // Post site info
+  public submitForm(data): Observable<any> {
+    console.log(data)
+    return data;
+    // return this.httpClient.post<any>(api-url, data);
+  }
+
+  // Put landowner
+  public putLandowner(data): Observable<any> {
+    console.log(data)
+    return data;
+  }
+
+  public postLandowner(data): Observable<any> {
+    console.log(data)
+    return data;
+  }
+
+  public postNetworkNames(data): Observable<any> {
+    // params: { siteId: '@siteId', NetworkNameId: '@networkNameId' }, isArray: true, url: rootURL + '/sites/:siteId/AddNetworkName'
+    console.log(data)
+    return data;
+  }
+
+  public deleteNetworkNames(data): Observable<any> {
+    // url: rootURL + '/sites/:siteId/removeNetworkName?NetworkNameId=:networkNameId'
+    console.log(data)
+    return data;
+  }
+
+  public postNetworkTypes(data): Observable<any> {
+    // { siteId: '@siteId', NetworkTypeId: '@networkTypeId' }, isArray: true, url: rootURL + '/sites/:siteId/AddNetworkType'
+    console.log(data)
+    return data;
+  }
+
+  public deleteNetworkTypes(data): Observable<any> {
+    // url: rootURL + '/sites/:siteId/removeNetworkType?NetworkTypeId=:networkTypeId'
+    console.log(data)
+    return data;
+  }
+
+  public deleteSiteHousings(data): Observable<any> {
+    // rootURL + '/SiteHousings/:id.json'
+    console.log(data)
+    return data;
+  }
+
+  public postSiteHousings(data): Observable<any> {
+    // rootURL + '/SiteHousings/:id.json'
+    console.log(data)
+    return data;
+  }
+
+  public putSiteHousings(data): Observable<any> {
+    // rootURL + '/SiteHousings/:id.json'
+    console.log(data)
+    return data;
+  }
+
   /**
      * Handle Http operation that failed.
      * Let the app continue.
@@ -40,7 +100,7 @@ export class SiteEditService {
      * @param result - optional value to return as the observable result
      */
 
-   private handleError<T>(operation = 'operation', result?: T) {
+  private handleError<T>(operation = 'operation', result?: T) {
     return (error: any): Observable<T> => {
         // TODO: send the error to remote logging infrastructure
         console.error(error); // log to console instead
@@ -52,5 +112,5 @@ export class SiteEditService {
         // Let the app keep running by returning an empty result.
         return of(result as T);
     };
-}
+  }
 }

--- a/src/app/services/site-edit.service.ts
+++ b/src/app/services/site-edit.service.ts
@@ -73,7 +73,7 @@ export class SiteEditService {
   public postNetworkNames(siteID, networkNameID): Observable<any> {
     // params: { siteId: '@siteId', NetworkNameId: '@networkNameId' }, isArray: true, url: rootURL + '/sites/:siteId/AddNetworkName'
     return this.httpClient
-        .post(APP_SETTINGS.SITES_URL + '/' + siteID + '/AddNetworkName?NetworkNameId=' + networkNameID, {
+        .post(APP_SETTINGS.API_ROOT + 'sites/' + siteID + '/AddNetworkName?NetworkNameId=' + networkNameID, { siteId: siteID, NetworkNameId: networkNameID }, {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
       })
         .pipe(
@@ -107,9 +107,8 @@ export class SiteEditService {
   }
 
   public postNetworkTypes(siteID, networkTypeID): Observable<any> {
-    // { siteId: '@siteId', NetworkTypeId: '@networkTypeId' }, isArray: true, url: rootURL + '/sites/:siteId/AddNetworkType'
     return this.httpClient
-        .post(APP_SETTINGS.SITES_URL + '/' + siteID + '/AddNetworkType?NetworkTypeId=' + networkTypeID, {
+        .post(APP_SETTINGS.API_ROOT + 'sites/' + siteID + '/AddNetworkType?NetworkTypeId=' + networkTypeID, { siteId: siteID, NetworkNameId: networkTypeID }, {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
       })
         .pipe(
@@ -127,7 +126,7 @@ export class SiteEditService {
   public deleteNetworkTypes(siteID, networkTypeID): Observable<any> {
     // url: rootURL + '/sites/:siteId/removeNetworkType?NetworkTypeId=:networkTypeId'
     return this.httpClient
-        .delete(APP_SETTINGS.SITES_URL + '/sites/' + siteID + '/removeNetworkType?NetworkTypeId=' + networkTypeID,  {
+        .delete(APP_SETTINGS.API_ROOT + 'sites/' + siteID + '/removeNetworkType?NetworkTypeId=' + networkTypeID, {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
       })
         .pipe(
@@ -231,6 +230,40 @@ export class SiteEditService {
             catchError(this.handleError<any>('uploadFile', []))
         );
   }
+
+  public saveFile(file): Observable<any> {
+      return this.httpClient
+          .post(APP_SETTINGS.API_ROOT + 'Files.json',  file, {
+            headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+        })
+          .pipe(
+              tap((response) => {
+                  console.log(
+                      'saveFile response received' //: ' +
+                      // JSON.stringify(response)
+                  );
+                  return response;
+              }),
+              catchError(this.handleError<any>('saveFile', []))
+          );
+    }
+
+    public updateFile(file): Observable<any> {
+        return this.httpClient
+            .put(APP_SETTINGS.API_ROOT + 'Files/' + file.file_id + '.json',  file, {
+              headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+          })
+            .pipe(
+                tap((response) => {
+                    console.log(
+                        'updateFile response received' //: ' +
+                        // JSON.stringify(response)
+                    );
+                    return response;
+                }),
+                catchError(this.handleError<any>('updateFile', []))
+            );
+      }
 
   public deleteFile(sourceID, file): Observable<any> {
     // uploadFile: { method: 'POST', url: rootURL + '/Files/bytes', headers: { 'Content-Type': undefined }, transformRequest: angular.identity, cache: false, isArray: false },

--- a/src/app/services/site-edit.service.ts
+++ b/src/app/services/site-edit.service.ts
@@ -15,10 +15,9 @@ export class SiteEditService {
   }
 
   //Update single site by ID
-  public updateSingleSite(siteID: string): Observable<any> {
-    console.log(APP_SETTINGS.SITES_URL);
+  public putSite(siteID: string): Observable<any> {
     return this.httpClient
-        .get(APP_SETTINGS.SITES_URL + '/' + siteID + '.json',  {
+        .put(APP_SETTINGS.SITES_URL + '/' + siteID + '.json',  {
           headers: APP_SETTINGS.AUTH_JSON_HEADERS,
       })
         .pipe(
@@ -33,64 +32,207 @@ export class SiteEditService {
         );
   }
 
-  // Post site info
-  public submitForm(data): Observable<any> {
-    console.log(data)
-    return data;
-    // return this.httpClient.post<any>(api-url, data);
-  }
-
   // Put landowner
-  public putLandowner(data): Observable<any> {
-    console.log(data)
-    return data;
+  public putLandowner(landownerContactID): Observable<any> {
+    // rootURL + '/LandOwners/:id.json'
+    // return this.httpClient
+    //     .put(APP_SETTINGS.SITES_URL + '/LandOwners/' + landownerContactID + '.json',  {
+    //       headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+    //   })
+    //     .pipe(
+    //         tap((response) => {
+    //             console.log(
+    //                 'putLandowner response received' //: ' +
+    //                 // JSON.stringify(response)
+    //             );
+    //             return response;
+    //         }),
+    //         catchError(this.handleError<any>('putLandowner', []))
+    //     );
+    return landownerContactID;
   }
 
-  public postLandowner(data): Observable<any> {
-    console.log(data)
-    return data;
+  public postLandowner(landownerContactID): Observable<any> {
+    // rootURL + '/LandOwners/:id.json'
+    return this.httpClient
+        .post(APP_SETTINGS.SITES_URL + '/LandOwners/' + landownerContactID + '.json',  {
+          headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+      })
+        .pipe(
+            tap((response) => {
+                console.log(
+                    'postLandowner response received' //: ' +
+                    // JSON.stringify(response)
+                );
+                return response;
+            }),
+            catchError(this.handleError<any>('postLandowner', []))
+        );
   }
 
-  public postNetworkNames(data): Observable<any> {
+  public postNetworkNames(siteID, networkNameID): Observable<any> {
     // params: { siteId: '@siteId', NetworkNameId: '@networkNameId' }, isArray: true, url: rootURL + '/sites/:siteId/AddNetworkName'
-    console.log(data)
-    return data;
+    return this.httpClient
+        .post(APP_SETTINGS.SITES_URL + '/sites' + siteID + 'AddNetworkName',  {
+          headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+          params: { siteId: siteID, NetworkNameId: networkNameID },
+      })
+        .pipe(
+            tap((response) => {
+                console.log(
+                    'postNetworkNames response received' //: ' +
+                    // JSON.stringify(response)
+                );
+                return response;
+            }),
+            catchError(this.handleError<any>('postNetworkNames', []))
+        );
   }
 
-  public deleteNetworkNames(data): Observable<any> {
+  public deleteNetworkNames(siteID, networkNameID): Observable<any> {
     // url: rootURL + '/sites/:siteId/removeNetworkName?NetworkNameId=:networkNameId'
-    console.log(data)
-    return data;
+    return this.httpClient
+        .delete(APP_SETTINGS.SITES_URL + '/sites/' + siteID + '/removeNetworkName?NetworkNameId=' + networkNameID,  {
+          headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+      })
+        .pipe(
+            tap((response) => {
+                console.log(
+                    'deleteNetworkNames response received' //: ' +
+                    // JSON.stringify(response)
+                );
+                return response;
+            }),
+            catchError(this.handleError<any>('deleteNetworkNames', []))
+        );
   }
 
-  public postNetworkTypes(data): Observable<any> {
+  public postNetworkTypes(siteID, networkTypeID): Observable<any> {
     // { siteId: '@siteId', NetworkTypeId: '@networkTypeId' }, isArray: true, url: rootURL + '/sites/:siteId/AddNetworkType'
-    console.log(data)
-    return data;
+    return this.httpClient
+        .post(APP_SETTINGS.SITES_URL + '/sites/' + siteID + '/AddNetworkType',  {
+          headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+          params: { siteId: siteID, NetworkTypeId: networkTypeID },
+      })
+        .pipe(
+            tap((response) => {
+                console.log(
+                    'postNetworkTypes response received' //: ' +
+                    // JSON.stringify(response)
+                );
+                return response;
+            }),
+            catchError(this.handleError<any>('postNetworkTypes', []))
+        );
   }
 
-  public deleteNetworkTypes(data): Observable<any> {
+  public deleteNetworkTypes(siteID, networkTypeID): Observable<any> {
     // url: rootURL + '/sites/:siteId/removeNetworkType?NetworkTypeId=:networkTypeId'
-    console.log(data)
-    return data;
+    return this.httpClient
+        .delete(APP_SETTINGS.SITES_URL + '/sites/' + siteID + '/removeNetworkType?NetworkTypeId=' + networkTypeID,  {
+          headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+      })
+        .pipe(
+            tap((response) => {
+                console.log(
+                    'deleteNetworkTypes response received' //: ' +
+                    // JSON.stringify(response)
+                );
+                return response;
+            }),
+            catchError(this.handleError<any>('deleteNetworkTypes', []))
+        );
   }
 
-  public deleteSiteHousings(data): Observable<any> {
+  public deleteSiteHousings(siteHousingID): Observable<any> {
     // rootURL + '/SiteHousings/:id.json'
-    console.log(data)
-    return data;
+    return this.httpClient
+        .delete(APP_SETTINGS.SITES_URL + '/SiteHousings/' + siteHousingID + '.json',  {
+          headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+      })
+        .pipe(
+            tap((response) => {
+                console.log(
+                    'deleteSiteHousings response received' //: ' +
+                    // JSON.stringify(response)
+                );
+                return response;
+            }),
+            catchError(this.handleError<any>('deleteSiteHousings', []))
+        );
   }
 
-  public postSiteHousings(data): Observable<any> {
+  public postSiteHousings(siteHousingID): Observable<any> {
     // rootURL + '/SiteHousings/:id.json'
-    console.log(data)
-    return data;
+    return this.httpClient
+        .post(APP_SETTINGS.SITES_URL + '/SiteHousings/' + siteHousingID + '.json',  {
+          headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+      })
+        .pipe(
+            tap((response) => {
+                console.log(
+                    'postSiteHousings response received' //: ' +
+                    // JSON.stringify(response)
+                );
+                return response;
+            }),
+            catchError(this.handleError<any>('postSiteHousings', []))
+        );
   }
 
-  public putSiteHousings(data): Observable<any> {
+  public putSiteHousings(siteHousingID): Observable<any> {
     // rootURL + '/SiteHousings/:id.json'
-    console.log(data)
-    return data;
+    return this.httpClient
+        .put(APP_SETTINGS.SITES_URL + '/SiteHousings/' + siteHousingID + '.json',  {
+          headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+      })
+        .pipe(
+            tap((response) => {
+                console.log(
+                    'putSiteHousings response received' //: ' +
+                    // JSON.stringify(response)
+                );
+                return response;
+            }),
+            catchError(this.handleError<any>('putSiteHousings', []))
+        );
+  }
+
+  public postSource(sourceID): Observable<any> {
+    // rootURL + '/Sources/:id.json'
+    return this.httpClient
+        .post(APP_SETTINGS.SITES_URL + '/Sources/' + sourceID + '.json',  {
+          headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+      })
+        .pipe(
+            tap((response) => {
+                console.log(
+                    'postSource response received' //: ' +
+                    // JSON.stringify(response)
+                );
+                return response;
+            }),
+            catchError(this.handleError<any>('postSource', []))
+        );
+  }
+  
+  public uploadFile(sourceID): Observable<any> {
+  // uploadFile: { method: 'POST', url: rootURL + '/Files/bytes', headers: { 'Content-Type': undefined }, transformRequest: angular.identity, cache: false, isArray: false },
+    // return this.httpClient
+    //     .post(APP_SETTINGS.SITES_URL + 'Files/bytes',  {
+    //       headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+    //   })
+    //     .pipe(
+    //         tap((response) => {
+    //             console.log(
+    //                 'uploadFile response received' //: ' +
+    //                 // JSON.stringify(response)
+    //             );
+    //             return response;
+    //         }),
+    //         catchError(this.handleError<any>('uploadFile', []))
+    //     );
+    return sourceID;
   }
 
   /**

--- a/src/app/services/site-edit.service.ts
+++ b/src/app/services/site-edit.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@angular/core';
+import { APP_SETTINGS } from '../app.settings';
+import { APP_UTILITIES } from '@app/app.utilities';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs/Observable';
+import { catchError, tap } from 'rxjs/operators';
+import { of } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SiteEditService {
+
+  constructor(private httpClient: HttpClient) {
+  }
+
+  //Update single site by ID
+  public updateSingleSite(siteID: string): Observable<any> {
+    console.log(APP_SETTINGS.SITES_URL);
+    return this.httpClient
+        .get(APP_SETTINGS.SITES_URL + '/' + siteID + '.json',  {
+          headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+      })
+        .pipe(
+            tap((response) => {
+                console.log(
+                    'updateSingleSite response received' //: ' +
+                    // JSON.stringify(response)
+                );
+                return response;
+            }),
+            catchError(this.handleError<any>('updateSingleSite', []))
+        );
+  }
+
+  /**
+     * Handle Http operation that failed.
+     * Let the app continue.
+     * @param operation - name of the operation that failed
+     * @param result - optional value to return as the observable result
+     */
+
+   private handleError<T>(operation = 'operation', result?: T) {
+    return (error: any): Observable<T> => {
+        // TODO: send the error to remote logging infrastructure
+        console.error(error); // log to console instead
+
+        // TODO: better job of transforming error for user consumption
+        // Consider creating a message service for this (https://angular.io/tutorial/toh-pt4)
+        console.log(`${operation} failed: ${error.message}`);
+
+        // Let the app keep running by returning an empty result.
+        return of(result as T);
+    };
+}
+}

--- a/src/app/services/site.service.ts
+++ b/src/app/services/site.service.ts
@@ -207,6 +207,36 @@ export class SiteService {
             );
     }
 
+    //Get network types
+    public getNetworkTypesList(): Observable<any> {
+        return this.httpClient
+            .get(APP_SETTINGS.API_ROOT + '/NetworkTypes.json')
+            .pipe(
+                tap((response) => {
+                    console.log(
+                        'getNetworkTypesList response received'
+                    );
+                    return response;
+                }),
+                catchError(this.handleError<any>('getNetworkTypesList', []))
+            );
+    }
+
+    //Get network names
+    public getNetworkNamesList(): Observable<any> {
+        return this.httpClient
+            .get(APP_SETTINGS.API_ROOT + '/NetworkNames.json')
+            .pipe(
+                tap((response) => {
+                    console.log(
+                        'getNetworkNamesList response received'
+                    );
+                    return response;
+                }),
+                catchError(this.handleError<any>('getNetworkNamesList', []))
+            );
+    }
+
     //Get landowner contact
     public getLandownerContact(siteID): Observable<any> {
         return this.httpClient
@@ -727,6 +757,50 @@ export class SiteService {
             );
     }
 
+    // Get all counties in state
+    public getAllCounties(state_id): Observable<any> {
+        return this.httpClient
+            .get(APP_SETTINGS.API_ROOT + 'States/' + state_id + '/Counties.json')
+            .pipe(
+                tap((response) => {
+                    console.log(
+                        'getAllCounties response received'
+                    );
+                    return response;
+                }),
+                catchError(this.handleError<any>('getAllCounties', []))
+            );
+    }
+
+    // Get all states
+    public getAllStates(): Observable<any> {
+        return this.httpClient
+            .get(APP_SETTINGS.API_ROOT + 'States.json')
+            .pipe(
+                tap((response) => {
+                    console.log(
+                        'getAllStates response received'
+                    );
+                    return response;
+                }),
+                catchError(this.handleError<any>('getAllStates', []))
+            );
+    }
+
+    // Get all housing types
+    public getAllHousingTypes(): Observable<any> {
+        return this.httpClient
+            .get(APP_SETTINGS.API_ROOT + 'HousingTypes.json')
+            .pipe(
+                tap((response) => {
+                    console.log(
+                        'getAllHousingTypes response received'
+                    );
+                    return response;
+                }),
+                catchError(this.handleError<any>('getAllHousingTypes', []))
+            );
+    }
 
     public setCurrentEvent(currentEvent: number) {
         this.event.next(currentEvent);

--- a/src/app/services/site.service.ts
+++ b/src/app/services/site.service.ts
@@ -672,6 +672,21 @@ export class SiteService {
             );
     }
 
+    //Get File Type Lookup
+    public getFileTypeLookup(): Observable<any> {
+        return this.httpClient
+            .get(APP_SETTINGS.API_ROOT + 'FileTypes/.json')
+            .pipe(
+                tap((response) => {
+                    console.log(
+                        'getFileTypeLookup response received'
+                    );
+                    return response;
+                }),
+                catchError(this.handleError<any>('getFileTypeLookup', []))
+            );
+    }
+
     //Get File Source
     public getFileSource(sourceID): Observable<any> {
         return this.httpClient
@@ -686,6 +701,23 @@ export class SiteService {
                     return response;
                 }),
                 catchError(this.handleError<any>('getFileSource', []))
+            );
+    }
+
+    //Get all agencies
+    public getAgencyLookup(): Observable<any> {
+        return this.httpClient
+            .get(APP_SETTINGS.API_ROOT + 'Agencies.json', {
+                headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+            })
+            .pipe(
+                tap((response) => {
+                    console.log(
+                        'getAgencyLookup response received'
+                    );
+                    return response;
+                }),
+                catchError(this.handleError<any>('getAgencyLookup', []))
             );
     }
 
@@ -802,9 +834,54 @@ export class SiteService {
             );
     }
 
+    // Get Site Deployment Priority
+    public getDepPriority(site_id): Observable<any> {
+        return this.httpClient
+            .get(APP_SETTINGS.SITES_URL + '/' + site_id + '/DeploymentPriorities.json')
+            .pipe(
+                tap((response) => {
+                    console.log(
+                        'getDepPriority response received'
+                    );
+                    return response;
+                }),
+                catchError(this.handleError<any>('getDepPriority', []))
+            );
+    }
+
+    // Get Site Deployment Priority
+    public getPriorities(): Observable<any> {
+        return this.httpClient
+            .get(APP_SETTINGS.API_ROOT + 'DeploymentPriorities.json')
+            .pipe(
+                tap((response) => {
+                    console.log(
+                        'getPriorities response received'
+                    );
+                    return response;
+                }),
+                catchError(this.handleError<any>('getPriorities', []))
+            );
+    }
+
+    // Get File Item
+    public getFileItem(file_id): Observable<any> {
+        return this.httpClient
+            .get(APP_SETTINGS.API_ROOT + 'Files/' + file_id + '/item', {headers: APP_SETTINGS.AUTH_JSON_HEADERS},)
+            .pipe(
+                tap((response) => {
+                    console.log(
+                        'getFileItem response received'
+                    );
+                    return response;
+                }),
+                catchError(this.handleError<any>('getFileItem', []))
+            );
+    }
+
     public setCurrentEvent(currentEvent: number) {
         this.event.next(currentEvent);
-    }  
+    }
     
     //Get site events
     public getCurrentEvent(): Observable<any> {

--- a/src/app/site-details/site-details.component.html
+++ b/src/app/site-details/site-details.component.html
@@ -759,11 +759,11 @@
                                     <ng-container matColumnDef="FileDate">
                                         <th mat-header-cell *matHeaderCellDef>File Date</th>
                                         <td mat-cell *matCellDef="let file">
-                                            <div *ngIf="file.file_date === '' || file.file_date === undefined; else displaySiteFileDate">
+                                            <div *ngIf="file.format_file_date === '' || file.format_file_date === undefined; else displaySiteFileDate">
                                                 ---
                                             </div>
                                             <ng-template #displaySiteFileDate>
-                                                {{ file.file_date }}
+                                                {{ file.format_file_date }}
                                             </ng-template>
                                         </td>
                                     </ng-container>

--- a/src/app/site-details/site-details.component.html
+++ b/src/app/site-details/site-details.component.html
@@ -228,12 +228,12 @@
                                 <div class="outer-content" *ngIf="site !== undefined">
                                     <div class="cell-container">
                                         <p class="content-left">Latitude</p>
-                                        <p class="content-right" *ngIf="site.latitude_dd !== '' && site.latitude_dd !== undefined; else nullLat">{{site.latitude_dd.toFixed(2)}}</p>
+                                        <p class="content-right" *ngIf="site.latitude_dd !== '' && site.latitude_dd !== undefined; else nullLat">{{site.latitude_dd}}</p>
                                         <ng-template #nullLat><p class="content-right">---</p></ng-template>
                                     </div>
                                     <div class="cell-container">
                                         <p class="content-left">Longitude</p>
-                                        <p class="content-right" *ngIf="site.longitude_dd !== '' && site.longitude_dd !== undefined; else nullLon">{{site.longitude_dd.toFixed(2)}}</p>
+                                        <p class="content-right" *ngIf="site.longitude_dd !== '' && site.longitude_dd !== undefined; else nullLon">{{site.longitude_dd}}</p>
                                         <ng-template #nullLon><p class="content-right">---</p></ng-template>
                                     </div>
                                     <div class="cell-container">

--- a/src/app/site-details/site-details.component.html
+++ b/src/app/site-details/site-details.component.html
@@ -180,6 +180,11 @@
                                 <p class="content-right" *ngIf="site.other_sid !== '' && site.noaa_sid !== undefined; else nullOther">{{site.other_sid}}</p>
                                 <ng-template #nullOther><p class="content-right">---</p></ng-template>
                             </div>
+                            <div class="cell-container">
+                                <p class="content-left">Priority</p>
+                                <p class="content-right" *ngIf="priority !== '' && priority !== undefined && priority !== null; else nullPriority">{{priority.priority_name}}</p>
+                                <ng-template #nullPriority><p class="content-right">---</p></ng-template>
+                            </div>
                         </div>
                     </div>
                     <mat-accordion multi="true">

--- a/src/app/site-details/site-details.component.html
+++ b/src/app/site-details/site-details.component.html
@@ -14,11 +14,19 @@
                 <mat-tab label="Site">
                     <div class="basic-site-info">
                         <div id="siteMap">
-                            <button mat-button class="map-button" (click)="toggleSiteMap()">
-                                <span *ngIf="siteMapHidden">View site on map <mat-icon class="expand-icon">expand_more</mat-icon></span>
-                                <span *ngIf="!siteMapHidden">Hide map <mat-icon class="expand-icon">expand_less</mat-icon></span>
-                            </button>
+                                <div class="left">
+                                    <button mat-raised-button class="edit-button" (click)="openEditDialog()"><mat-icon>edit</mat-icon> Edit Site</button>
+                                </div>
+                                <div class="right">
+                                    <button mat-raised-button disabled class="delete-button"><mat-icon>delete_forever</mat-icon> Delete Site</button>
+                                    <mat-icon class="info-icon" matTooltip="To delete a site, please contact a STN administrator." 
+                                        aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
+                                </div>
                         </div>
+                        <button mat-raised-button class="map-button" (click)="toggleSiteMap()">
+                            <span *ngIf="siteMapHidden">View site on map <mat-icon class="expand-icon">expand_more</mat-icon></span>
+                            <span *ngIf="!siteMapHidden">Hide map <mat-icon class="expand-icon">expand_less</mat-icon></span>
+                        </button>
                         <div id="mapContainer">
                             <mat-accordion id="legend">
                                 <mat-expansion-panel id="legend-expansion" expanded="true">

--- a/src/app/site-details/site-details.component.html
+++ b/src/app/site-details/site-details.component.html
@@ -15,7 +15,7 @@
                     <div class="basic-site-info">
                         <div id="siteMap">
                                 <div class="left">
-                                    <button mat-raised-button class="edit-button" (click)="openEditDialog()"><mat-icon>edit</mat-icon> Edit Site</button>
+                                    <button mat-raised-button class="edit-button" [disabled]="editDisabled" (click)="openEditDialog()"><mat-icon>edit</mat-icon> Edit Site</button>
                                 </div>
                                 <div class="right">
                                     <button mat-raised-button disabled class="delete-button"><mat-icon>delete_forever</mat-icon> Delete Site</button>

--- a/src/app/site-details/site-details.component.html
+++ b/src/app/site-details/site-details.component.html
@@ -362,12 +362,12 @@
                                 <div class="outer-content" *ngIf="site !== undefined">
                                     <div class="cell-container">
                                         <p class="content-left">Network Type</p>
-                                        <p class="content-right" *ngIf="networkType !== undefined; else nullNetworkType">{{networkType}}</p>
+                                        <p class="content-right" *ngIf="networkType !== undefined && networkType !== ''; else nullNetworkType">{{networkType}}</p>
                                         <ng-template #nullNetworkType><p class="content-right">---</p></ng-template>
                                     </div>
                                     <div class="cell-container">
                                         <p class="content-left">Network</p>
-                                        <p class="content-right" *ngIf="networkName !== undefined; else nullNetwork">{{networkName}}</p>
+                                        <p class="content-right" *ngIf="networkName !== undefined && networkName !== ''; else nullNetwork">{{networkName}}</p>
                                         <ng-template #nullNetwork><p class="content-right">---</p></ng-template>
                                     </div>
                                     <div class="cell-container">

--- a/src/app/site-details/site-details.component.scss
+++ b/src/app/site-details/site-details.component.scss
@@ -215,9 +215,13 @@ table {
 
 // Site information
 #siteMap {
-    width: 50%;
-    display: inline-block;
-    text-align: left;
+    display: flex;
+    margin: auto;
+    width: 100%;
+}
+
+#siteMapContainer {
+    display: table-row;
 }
 
 #mapContainer {
@@ -227,12 +231,8 @@ table {
     margin-bottom: 20px;
 }
 
-.map-button {
+.delete-button {
     margin: 5px 5px;
-    background-color: white;
-    border: 1px solid rgba(0, 0, 0, 0.2);;
-    font-size: 15px;
-    font-weight: bold;
 }
 
 .table-container {
@@ -259,6 +259,28 @@ table {
     padding-right: 5px;
     text-align: right;
     font-weight: bold;
+}
+
+.map-button {
+    margin: 5px 5px;
+}
+
+.edit-button {
+    margin: 5px 5px;
+}
+
+.left {
+    flex: 1;
+    text-align: right;
+}
+
+.right {
+    flex: 1;
+}
+
+.info-icon {
+    font-size: 20px;
+    color: #03274B;
 }
 
 #landowner {

--- a/src/app/site-details/site-details.component.scss
+++ b/src/app/site-details/site-details.component.scss
@@ -222,9 +222,13 @@ table {
 
 // Site information
 #siteMap {
-    width: 50%;
-    display: inline-block;
-    text-align: left;
+    display: flex;
+    margin: auto;
+    width: 100%;
+}
+
+#siteMapContainer {
+    display: table-row;
 }
 
 #mapContainer {
@@ -240,6 +244,10 @@ table {
     border: 1px solid rgba(0, 0, 0, 0.2);;
     font-size: 15px;
     font-weight: bold;
+}
+
+.delete-button {
+    margin: 5px 5px;
 }
 
 .table-container {
@@ -266,6 +274,19 @@ table {
     padding-right: 5px;
     text-align: right;
     font-weight: bold;
+}
+
+.edit-button {
+    margin: 5px 5px;
+}
+
+.left {
+    flex: 1;
+    text-align: right;
+}
+
+.right {
+    flex: 1;
 }
 
 #landowner {

--- a/src/app/site-details/site-details.component.spec.ts
+++ b/src/app/site-details/site-details.component.spec.ts
@@ -13,6 +13,7 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { of } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { not } from '@angular/compiler/src/output/output_ast';
+import { CurrentUserService } from '@services/current-user.service';
 
 declare let L: any;
 import 'leaflet';
@@ -36,6 +37,7 @@ describe('SiteDetailsComponent', () => {
             providers: [
                 { provide: ActivatedRoute, useValue: fakeActivatedRoute },
                 { provide: MatDialogRef, useValue: dialogMock },
+                CurrentUserService,
             ],
             imports: [HttpClientTestingModule,
                 MatDialogModule,
@@ -242,7 +244,7 @@ describe('SiteDetailsComponent', () => {
 
     it('should call getMemberName if site has member_id', () => {
         const siteResponse = {member_id: 4};
-        const response = [{fname: "John", lname: "Smith"}];
+        const response = {fname: "John", lname: "Smith"};
 
         spyOn(component.siteService, 'getSingleSite').and.returnValue(
             of(siteResponse)
@@ -368,7 +370,7 @@ describe('SiteDetailsComponent', () => {
         expect(component.sensorFiles.length).toEqual(1);
         expect(component.sensorFilesDone).toBeTrue;
         expect(siteFilesSpy).toHaveBeenCalled();
-        expect(component.files[0].file_date).toContain("/");
+        expect(component.files[0].format_file_date).toContain("/");
         expect(component.files[2].details).not.toEqual(undefined);
     });
 

--- a/src/app/site-details/site-details.component.ts
+++ b/src/app/site-details/site-details.component.ts
@@ -816,6 +816,7 @@ export class SiteDetailsComponent implements OnInit {
             material: null,
             length: null,
             site_housing_id: null,
+            housing_type_id: null,
         }];
         this.siteHousing.forEach(function(value){
             siteHousing[0].amount = value.amount !== undefined && value.amount !== "" ? value.amount : null;
@@ -824,6 +825,7 @@ export class SiteDetailsComponent implements OnInit {
             siteHousing[0].material = value.material !== undefined && value.material !== "" ? value.material : null;
             siteHousing[0].length = value.length !== undefined && value.length !== "" ? value.length : null;
             siteHousing[0].site_housing_id = value.site_housing_id !== undefined && value.site_housing_id !== "" ? value.site_housing_id : null;
+            siteHousing[0].housing_type_id = value.housing_type_id !== undefined && value.housing_type_id !== "" ? value.housing_type_id : null;
         })
 
         if(this.currentUser !== ''){

--- a/src/app/site-details/site-details.component.ts
+++ b/src/app/site-details/site-details.component.ts
@@ -114,6 +114,8 @@ export class SiteDetailsComponent implements OnInit {
         zoomToBoundsOnClick: false
     });
     public currentUser;
+    // Disable edit button for some roles
+    editDisabled = localStorage.role !== '3' && localStorage.role !== '2' && localStorage.role !== '1';
 
     displayedColumns: string[] = [
         'HousingType',
@@ -871,8 +873,6 @@ export class SiteDetailsComponent implements OnInit {
             row.format_photo_date = photoDate;
         }
 
-        console.log(row)
-
         let dialogWidth;
         if (window.matchMedia('(max-width: 768px)').matches) {
             dialogWidth = '80%';
@@ -895,7 +895,7 @@ export class SiteDetailsComponent implements OnInit {
     openEditDialog(){
         let siteHousing = JSON.parse(JSON.stringify(this.siteHousing));
 
-        if(this.currentUser !== ''){
+        if(localStorage.role === '3' || localStorage.role === '2' || localStorage.role === '1'){
             const dialogRef = this.dialog.open(SiteEditComponent, {
                 data: {
                     site: this.site,
@@ -913,42 +913,56 @@ export class SiteDetailsComponent implements OnInit {
             });
             dialogRef.afterClosed().subscribe((result) => {
                 if(result){
-                    // Update site details page with any edits
-                    let siteResultCopy = JSON.parse(JSON.stringify(result.site));
-                    let currentSiteCopy = JSON.parse(JSON.stringify(this.site));
-                    delete siteResultCopy.last_updated; delete siteResultCopy.last_updated_by; delete currentSiteCopy.last_updated; delete currentSiteCopy.last_updated_by;
-                    // copy and remove last updated info to compare
-                    // Site info changed
-                    if(siteResultCopy !== currentSiteCopy){
-                        console.log("site changed")
-                        this.site = result.site;
+                    console.log(result)
+                    if(result.site !== null){
+                        // Update site details page with any edits
+                        let siteResultCopy = JSON.parse(JSON.stringify(result.site));
+                        let currentSiteCopy = JSON.parse(JSON.stringify(this.site));
+                        delete siteResultCopy.last_updated; delete siteResultCopy.last_updated_by; delete currentSiteCopy.last_updated; delete currentSiteCopy.last_updated_by;
+                        // copy and remove last updated info to compare
+                        // Site info changed
+                        if(siteResultCopy !== currentSiteCopy){
+                            this.site = result.site;
+                        }
                     }
                     
-                    // Update housing
-                    let housingResultCopy = JSON.parse(JSON.stringify(result.housings));
-                    let currentHousingCopy = JSON.parse(JSON.stringify(this.siteHousing));
-                    delete housingResultCopy.last_updated; delete housingResultCopy.last_updated_by; delete currentHousingCopy.last_updated; delete currentHousingCopy.last_updated_by;
-                    if(currentHousingCopy !== housingResultCopy){
-                        console.log("site housing changed")                        
-                        this.siteHousing = result.housings;
-                    }
-                    console.log(result.networkName);
-                    console.log(this.networkName);
-                    console.log(result.networkType.join(','));
-
-                    // Update network types
-                    // let netTypeResultCopy = JSON.parse(JSON.stringify(result.networkType));
-                    // let currentNetTypeCopy = JSON.parse(JSON.stringify(this.networkType));
-                    // console.log(netTypeResultCopy, currentNetTypeCopy)
-                    // delete netTypeResultCopy.last_updated; delete netTypeResultCopy.last_updated_by; delete currentNetTypeCopy.last_updated; delete currentNetTypeCopy.last_updated_by;
-                    if(result.networkType.join(',') !== this.networkType){
-                        console.log("network types changed")
-                        this.networkType = result.networkType.join(',');
+                    if(result.housings.length > 0){
+                        // Update housing
+                        let housingResultCopy = JSON.parse(JSON.stringify(result.housings));
+                        let currentHousingCopy = JSON.parse(JSON.stringify(this.siteHousing));
+                        delete housingResultCopy.last_updated; delete housingResultCopy.last_updated_by; delete currentHousingCopy.last_updated; delete currentHousingCopy.last_updated_by;
+                        if(currentHousingCopy !== housingResultCopy){                     
+                            this.siteHousing = result.housings;
+                        }
                     }
 
-                    if(result.networkName.join(',') !== this.networkName){
-                        console.log("network names changed")
-                        this.networkName = result.networkName.join(',');
+                    if(result.networkType.length > 0){
+                        // Update network types
+                        // let netTypeResultCopy = JSON.parse(JSON.stringify(result.networkType));
+                        // let currentNetTypeCopy = JSON.parse(JSON.stringify(this.networkType));
+                        // console.log(netTypeResultCopy, currentNetTypeCopy)
+                        // delete netTypeResultCopy.last_updated; delete netTypeResultCopy.last_updated_by; delete currentNetTypeCopy.last_updated; delete currentNetTypeCopy.last_updated_by;
+                        if(result.networkType.join(',') !== this.networkType){
+                            console.log("network types changed")
+                            this.networkType = result.networkType.join(', ');
+                        }
+                    }
+
+                    if(result.networkType.length > 0){
+                        if(result.networkName.join(',') !== this.networkName){
+                            this.networkName = result.networkName.join(', ');
+                        }
+                    }
+
+                    // Files
+                    if(result.files.length > 0){
+                        this.siteFilesDataSource.data = result.files;
+                        this.fileLength = this.siteFilesDataSource.data.length + this.hwmFilesDataSource.data.length + this.refMarkFilesDataSource.data.length + this.sensorFilesDataSource.data.length;
+                    }
+
+                    // Landowner
+                    if(result.landowner !== null){
+                        console.log(result.landowner);
                     }
                 }
             });

--- a/src/app/site-details/site-details.component.ts
+++ b/src/app/site-details/site-details.component.ts
@@ -468,6 +468,7 @@ export class SiteDetailsComponent implements OnInit {
                             .getLandownerContact(this.siteID)
                             .subscribe((results) => {
                                 this.landownerContact = results;
+                                console.log(this.landownerContact);
                             });
                     }
 
@@ -814,6 +815,7 @@ export class SiteDetailsComponent implements OnInit {
             housingType: null,
             material: null,
             length: null,
+            site_housing_id: null,
         }];
         this.siteHousing.forEach(function(value){
             siteHousing[0].amount = value.amount !== undefined && value.amount !== "" ? value.amount : null;
@@ -821,6 +823,7 @@ export class SiteDetailsComponent implements OnInit {
             siteHousing[0].housingType = value.housingType !== undefined && value.housingType !== "" ? value.housingType : null;
             siteHousing[0].material = value.material !== undefined && value.material !== "" ? value.material : null;
             siteHousing[0].length = value.length !== undefined && value.length !== "" ? value.length : null;
+            siteHousing[0].site_housing_id = value.site_housing_id !== undefined && value.site_housing_id !== "" ? value.site_housing_id : null;
         })
 
         if(this.currentUser !== ''){

--- a/src/app/site-details/site-details.component.ts
+++ b/src/app/site-details/site-details.component.ts
@@ -946,12 +946,16 @@ export class SiteDetailsComponent implements OnInit {
                             console.log("network types changed")
                             this.networkType = result.networkType.join(', ');
                         }
+                    }else{
+                        this.networkType = '';
                     }
 
-                    if(result.networkType.length > 0){
+                    if(result.networkName.length > 0){
                         if(result.networkName.join(',') !== this.networkName){
                             this.networkName = result.networkName.join(', ');
                         }
+                    }else{
+                        this.networkName = '';
                     }
 
                     // Files
@@ -962,6 +966,7 @@ export class SiteDetailsComponent implements OnInit {
 
                     // Landowner
                     if(result.landowner !== null){
+                        this.landownerContact = result.landowner;
                         console.log(result.landowner);
                     }
                 }

--- a/src/app/site-details/site-details.component.ts
+++ b/src/app/site-details/site-details.component.ts
@@ -314,7 +314,7 @@ export class SiteDetailsComponent implements OnInit {
                                 let fileDate = file.file_date.split("T")[0];
                                 fileDate = fileDate.split("-");
                                 fileDate = fileDate[1] + "/" + fileDate[2] + "/" + fileDate[0];
-                                file.file_date = fileDate;
+                                file.format_file_date = fileDate;
                                 if(file.instrument_id !== undefined){
                                     self.siteService.getFileSensor(file.file_id).subscribe((results) => {
                                         file.details = results;
@@ -431,7 +431,7 @@ export class SiteDetailsComponent implements OnInit {
                                 let fileDate = file.file_date.split("T")[0];
                                 fileDate = fileDate.split("-");
                                 fileDate = fileDate[1] + "/" + fileDate[2] + "/" + fileDate[0];
-                                file.file_date = fileDate;
+                                file.format_file_date = fileDate;
                                 if (file.objective_point_id !== undefined){
                                     self.datumLocFiles.push(file);
                                     self.fileLength ++;
@@ -783,8 +783,10 @@ export class SiteDetailsComponent implements OnInit {
             let photoDate = row.photo_date.split("T")[0];
             photoDate = photoDate.split("-");
             photoDate = photoDate[1] + "/" + photoDate[2] + "/" + photoDate[0];
-            row.photo_date = photoDate;
+            row.format_photo_date = photoDate;
         }
+
+        console.log(row)
 
         let dialogWidth;
         if (window.matchMedia('(max-width: 768px)').matches) {
@@ -827,8 +829,6 @@ export class SiteDetailsComponent implements OnInit {
                     site: this.site,
                     networkType: this.networkType,
                     networkName: this.networkName,
-                    hdatum: this.hdatum,
-                    hmethod: this.hmethod,
                     hdatumList: this.hdatumList,
                     hmethodList: this.hmethodList,
                     siteFiles: this.siteFiles,

--- a/src/app/site-details/site-details.component.ts
+++ b/src/app/site-details/site-details.component.ts
@@ -18,6 +18,7 @@ import { DateTime } from "luxon";
 import { marker } from 'leaflet';
 import { SiteEditComponent } from '@app/site-edit/site-edit.component';
 import { ResultDetailsComponent } from '@app/result-details/result-details.component';
+import { networkInterfaces } from 'os';
 
 @Component({
     selector: 'app-site-details',
@@ -809,24 +810,7 @@ export class SiteDetailsComponent implements OnInit {
     }
 
     openEditDialog(){
-        let siteHousing = [{
-            amount: null,
-            notes: null,
-            housingType: null,
-            material: null,
-            length: null,
-            site_housing_id: null,
-            housing_type_id: null,
-        }];
-        this.siteHousing.forEach(function(value){
-            siteHousing[0].amount = value.amount !== undefined && value.amount !== "" ? value.amount : null;
-            siteHousing[0].notes = value.notes !== undefined && value.notes !== "" ? value.notes : null;
-            siteHousing[0].housingType = value.housingType !== undefined && value.housingType !== "" ? value.housingType : null;
-            siteHousing[0].material = value.material !== undefined && value.material !== "" ? value.material : null;
-            siteHousing[0].length = value.length !== undefined && value.length !== "" ? value.length : null;
-            siteHousing[0].site_housing_id = value.site_housing_id !== undefined && value.site_housing_id !== "" ? value.site_housing_id : null;
-            siteHousing[0].housing_type_id = value.housing_type_id !== undefined && value.housing_type_id !== "" ? value.housing_type_id : null;
-        })
+        let siteHousing = JSON.parse(JSON.stringify(this.siteHousing));
 
         if(this.currentUser !== ''){
             const dialogRef = this.dialog.open(SiteEditComponent, {
@@ -844,7 +828,47 @@ export class SiteDetailsComponent implements OnInit {
                 },
                 disableClose: true,
             });
-            dialogRef.afterClosed().subscribe((result) => {});
+            dialogRef.afterClosed().subscribe((result) => {
+                if(result){
+                    // Update site details page with any edits
+                    let siteResultCopy = JSON.parse(JSON.stringify(result.site));
+                    let currentSiteCopy = JSON.parse(JSON.stringify(this.site));
+                    delete siteResultCopy.last_updated; delete siteResultCopy.last_updated_by; delete currentSiteCopy.last_updated; delete currentSiteCopy.last_updated_by;
+                    // copy and remove last updated info to compare
+                    // Site info changed
+                    if(siteResultCopy !== currentSiteCopy){
+                        console.log("site changed")
+                        this.site = result.site;
+                    }
+                    
+                    // Update housing
+                    let housingResultCopy = JSON.parse(JSON.stringify(result.housings));
+                    let currentHousingCopy = JSON.parse(JSON.stringify(this.siteHousing));
+                    delete housingResultCopy.last_updated; delete housingResultCopy.last_updated_by; delete currentHousingCopy.last_updated; delete currentHousingCopy.last_updated_by;
+                    if(currentHousingCopy !== housingResultCopy){
+                        console.log("site housing changed")                        
+                        this.siteHousing = result.housings;
+                    }
+                    console.log(result.networkName);
+                    console.log(this.networkName);
+                    console.log(result.networkType.join(','));
+
+                    // Update network types
+                    // let netTypeResultCopy = JSON.parse(JSON.stringify(result.networkType));
+                    // let currentNetTypeCopy = JSON.parse(JSON.stringify(this.networkType));
+                    // console.log(netTypeResultCopy, currentNetTypeCopy)
+                    // delete netTypeResultCopy.last_updated; delete netTypeResultCopy.last_updated_by; delete currentNetTypeCopy.last_updated; delete currentNetTypeCopy.last_updated_by;
+                    if(result.networkType.join(',') !== this.networkType){
+                        console.log("network types changed")
+                        this.networkType = result.networkType.join(',');
+                    }
+
+                    if(result.networkName.join(',') !== this.networkName){
+                        console.log("network names changed")
+                        this.networkName = result.networkName.join(',');
+                    }
+                }
+            });
         }
     }
 }

--- a/src/app/site-details/site-details.component.ts
+++ b/src/app/site-details/site-details.component.ts
@@ -17,6 +17,7 @@ import 'leaflet';
 import { DateTime } from "luxon";
 import { marker } from 'leaflet';
 import { SiteEditComponent } from '@app/site-edit/site-edit.component';
+import { ResultDetailsComponent } from '@app/result-details/result-details.component';
 
 @Component({
     selector: 'app-site-details',
@@ -64,6 +65,7 @@ export class SiteDetailsComponent implements OnInit {
     public otherSensorVisible = false;
     public nearbySitesVisible = false;
     public nearbyToggled = false;
+    public priority;
     public nearbySites = L.featureGroup([]);
     public markers = L.markerClusterGroup({
         spiderfyOnMaxZoom: false,
@@ -239,6 +241,13 @@ export class SiteDetailsComponent implements OnInit {
                             })
                         }
 
+                    });
+
+                    // Get deployment priority
+                    this.siteService
+                    .getDepPriority(this.siteID)
+                    .subscribe((results) => {
+                        this.priority = results;
                     });
 
                     // If no event selected
@@ -825,6 +834,8 @@ export class SiteDetailsComponent implements OnInit {
                     siteFiles: this.siteFiles,
                     siteHousing: siteHousing,
                     memberName: this.memberName,
+                    priority: this.priority,
+                    landowner: this.landownerContact,
                 },
                 disableClose: true,
             });

--- a/src/app/site-edit/site-edit.component.html
+++ b/src/app/site-edit/site-edit.component.html
@@ -1,0 +1,283 @@
+<h2 mat-dialog-title>
+    Site
+    <!-- <button class="close-button" mat-button mat-dialog-close aria-mat-label="Exit"><mat-icon>close</mat-icon></button> -->
+</h2>
+<form [formGroup]="siteForm" (ngSubmit)="submitSiteForm()">
+    <mat-dialog-content>
+        <mat-accordion multi="true">
+            <mat-expansion-panel hideToggle expanded="false">
+                <mat-expansion-panel-header>
+                    <mat-panel-title>
+                    Site Information
+                    </mat-panel-title>
+                </mat-expansion-panel-header>
+                        <mat-form-field appearance="fill">
+                            <mat-label for="description">Site Description</mat-label>
+                            <textarea matInput formControlName="site_description" required id="description" [value]="site.description"></textarea>
+                            <mat-icon matSuffix class="info-icon" matTooltip="Brief description of the site area." 
+                            aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
+                        </mat-form-field>
+                        <mat-form-field appearance="fill">
+                            <mat-label>Internal Notes</mat-label>
+                            <textarea matInput formControlName="site_notes" [value]="site.internal_notes"></textarea>
+                        </mat-form-field>
+                        <mat-radio-group id="latLngUnit">
+                            <mat-radio-button class="radio-button" value="decdeg">Dec Deg</mat-radio-button>
+                            <mat-radio-button class="radio-button" value="dms">DMS</mat-radio-button>
+                        </mat-radio-group>                
+                        <mat-form-field appearance="fill">
+                            <mat-label>Latitude</mat-label>
+                            <input formControlName="latitude_dd" required matInput [value]="site.latitude_dd"/>
+                        </mat-form-field>
+                        <mat-form-field appearance="fill">
+                            <mat-label>Longitude</mat-label>
+                            <input formControlName = "longitude_dd" required matInput [value]="site.longitude_dd"/>
+                        </mat-form-field>
+                        <mat-form-field appearance="fill">
+                            <mat-label>Horizontal Datum</mat-label>
+                            <mat-select formControlName="hdatum" required [(value)]="site.hdatum">
+                                <mat-option *ngFor="let datum of hDatums" [value]="datum.datum_name">
+                                {{datum.datum_name}}
+                                </mat-option>
+                            </mat-select>
+                        </mat-form-field>
+                        <mat-form-field appearance="fill">
+                            <mat-label>Horizontal Collection Method</mat-label>
+                            <mat-select formControlName="hmethod" required [(value)]="site.hmethod">
+                                <mat-option *ngFor="let method of hMethods" [value]="method.hcollect_method">
+                                {{method.hcollect_method}}
+                                </mat-option>
+                            </mat-select>
+                        </mat-form-field>
+                        <mat-form-field appearance="fill">
+                            <mat-label>Waterbody</mat-label>
+                            <input formControlName="waterbody" required matInput [value]="site.waterbody"/>
+                            <mat-icon matSuffix class="info-icon" matTooltip="Required by NWIS.  Can be listed as 'Unknown' or 'Atlantic Ocean'" 
+                            aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
+                            <mat-hint>e.g. Atlantic Ocean</mat-hint>
+                        </mat-form-field>
+                        <mat-form-field appearance="fill">
+                            <mat-label>Drainage Area</mat-label>
+                            <input formControlName="drainage_area_sqmi" matInput [value]="site.drainage_area"/>
+                        </mat-form-field>
+                        <mat-form-field appearance="fill">
+                            <mat-label>Station ID for USGS Gage</mat-label>
+                            <input matInput formControlName="usgs_sid" [value]="site.usgs_id"/>
+                        </mat-form-field>
+                        <mat-form-field appearance="fill">
+                            <mat-label>Station ID for NOAA Gage</mat-label>
+                            <input matInput formControlName="noaa_sid" [value]="site.noaa_id"/>
+                        </mat-form-field>
+                        <mat-form-field appearance="fill">
+                            <mat-label>Other Station ID</mat-label>
+                            <input matInput formControlName="other_sid" [value]="site.other_id"/>
+                            <mat-hint>Please add details in the Site Description</mat-hint>
+                        </mat-form-field>
+                        <mat-form-field appearance="fill">
+                            <mat-label>Safety Notes</mat-label>
+                            <textarea matInput formControlName="safety_notes" [value]="site.safety_notes"></textarea>
+                        </mat-form-field>
+                        <mat-accordion multi="true">
+                            <mat-expansion-panel hideToggle>
+                            <mat-expansion-panel-header>
+                                <mat-panel-title>
+                                Location Information
+                                </mat-panel-title>
+                            </mat-expansion-panel-header>
+                                    <mat-form-field appearance="fill">
+                                        <mat-label>Address</mat-label>
+                                        <input matInput formControlName="address" [value]="site.address"/>
+                                    </mat-form-field>
+                                    <mat-form-field appearance="fill">
+                                        <mat-label>City</mat-label>
+                                        <input matInput formControlName="city" [value]="site.city"/>
+                                    </mat-form-field>
+                                    <mat-form-field appearance="fill">
+                                        <mat-label>State</mat-label>
+                                        <mat-select formControlName="state" required [(value)]="site.state" (selectionChange)="getCountyList($event.value)">
+                                            <mat-option *ngFor="let state of stateList" [value]="state.state_name">
+                                                {{state.state_name}}
+                                            </mat-option>
+                                        </mat-select>
+                                        <mat-icon matSuffix class="info-icon" matTooltip="Used to autogenerate the Site Number." 
+                                        aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
+                                    </mat-form-field>
+                                    <mat-form-field appearance="fill">
+                                        <mat-label>Zip</mat-label>
+                                        <input matInput formControlName="zip" [value]="site.zip"/>
+                                    </mat-form-field>
+                                    <mat-form-field appearance="fill">
+                                        <mat-label>County</mat-label>
+                                        <mat-select formControlName="county" required [(value)]="site.county">
+                                            <mat-option *ngFor="let county of countyList" [value]="county.county_name">
+                                                {{county.county_name}}
+                                            </mat-option>
+                                        </mat-select>
+                                        <mat-icon matSuffix class="info-icon" matTooltip="Used to autogenerate the Site Number. Use the Verify Location to populate." 
+                                        aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
+                                    </mat-form-field>
+                                    <mat-form-field appearance="fill">
+                                        <mat-label>Priority</mat-label>
+                                        <mat-select>
+
+                                        </mat-select>
+                                    </mat-form-field>
+                                    <div>Site Location Type in the Network</div>
+                                    <ul>
+                                        <li *ngFor="let type of networkTypes">
+                                        <mat-checkbox [checked]="type.selected" (change)="setSelected($event, type)">
+                                            {{type.network_type_name}}
+                                        </mat-checkbox>
+                                        </li>
+                                    </ul>
+                                    <div>Network Name</div>
+                                    <ul>
+                                        <li *ngFor="let name of networkNames" (change)="setSelected($event, name)">
+                                        <mat-checkbox [checked]="name.selected">
+                                            {{name.name}}
+                                        </mat-checkbox>
+                                        </li>
+                                    </ul>
+                                    <mat-form-field appearance="fill">
+                                        <mat-label>Zone</mat-label>
+                                        <input matInput [value]="site.zone"/>
+                                    </mat-form-field>
+                                    <mat-checkbox id="sensorAppropriate" [value]="sensorNotAppropriate">
+                                        Sensor Not Appropriate
+                                    </mat-checkbox>
+                                    <div>
+                                        <label>Permanent Housing Installed</label>
+                                        <mat-radio-group class="radio-group" [(value)]="perm_housing_installed" formControlName="is_permanent_housing_installed">
+                                            <mat-radio-button class="radio-button" value="Yes">Yes</mat-radio-button>
+                                            <mat-radio-button class="radio-button" value="No">No</mat-radio-button>
+                                        </mat-radio-group>
+                                    </div>
+                                    <div>
+                                        Site Creator {{site.memberName}}
+                                    </div>
+                                    <div>
+                                        <div>
+                                            <label>Landowner Contact</label><mat-icon matSuffix class="info-icon" matTooltip="Do not record information that private citizens have a reasonable expectation of privacy about. No names or phone numbers of private citizens.  Business contact information is acceptable." 
+                                            aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
+                                        </div>
+                                        <button mat-raised-button class="add-button"><mat-icon>add</mat-icon> Add Landowner</button>
+                                    </div>
+                                    <div>
+                                        <label>Access Permission Granted</label>
+                                        <mat-radio-group class="radio-group" [(value)]="accessGranted" formControlName="access_granted">
+                                            <mat-radio-button class="radio-button" value="Yes">Yes</mat-radio-button>
+                                            <mat-radio-button class="radio-button" value="No">No</mat-radio-button>
+                                            <mat-radio-button class="radio-button" value="Not Needed">Not Needed</mat-radio-button>
+                                        </mat-radio-group>
+                                    </div>
+                            </mat-expansion-panel>
+                            <mat-expansion-panel hideToggle>
+                                <mat-expansion-panel-header>
+                                    <mat-panel-title>
+                                    Housing Information
+                                    </mat-panel-title>
+                                </mat-expansion-panel-header>
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>Site Housing(s)</mat-label>
+                                            <mat-select [value]="siteHousingArray[0].housingType" (selectionChange)="changeTableValue($event.value)">
+                                                <mat-option *ngFor="let option of siteHousingLookup" [value]="option.type_name">
+                                                    {{option.type_name}}
+                                                </mat-option>
+                                            </mat-select>
+                                        </mat-form-field>
+                                        <div class="tableContainer">
+                                            <table
+                                                mat-table
+                                                id="siteHousingTable"
+                                                [dataSource]="siteHousingArray"
+                                                class="mat-elevation-z5"
+                                                matSort
+                                            >
+
+                                                <!-- housing type column -->
+                                                <ng-container matColumnDef="HousingType">
+                                                    <th mat-header-cell *matHeaderCellDef>Housing Type</th>
+                                                    <td mat-cell *matCellDef="let housing">
+                                                        <div>
+                                                            {{housing.housingType}}
+                                                        </div>
+                                                    </td>
+                                                </ng-container>
+
+                                                <!-- housing length column -->
+                                                <ng-container matColumnDef="HousingLength">
+                                                    <th mat-header-cell *matHeaderCellDef>Housing Length (ft)</th>
+                                                    <td mat-cell *matCellDef="let housing">
+                                                        <mat-form-field appearance="fill">
+                                                            <input matInput [value]="housing.length"/>
+                                                        </mat-form-field>
+                                                    </td>
+                                                </ng-container>
+
+                                                <!-- housing material column -->
+                                                <ng-container matColumnDef="HousingMaterial">
+                                                    <th mat-header-cell *matHeaderCellDef>Housing Material</th>
+                                                    <td mat-cell *matCellDef="let housing">
+                                                        <mat-form-field appearance="fill">
+                                                            <input matInput [value]="housing.material"/>
+                                                        </mat-form-field>
+                                                    </td>
+                                                </ng-container>
+
+                                                <!-- amount column -->
+                                                <ng-container matColumnDef="Amount">
+                                                    <th
+                                                        mat-header-cell
+                                                        *matHeaderCellDef
+                                                    >
+                                                        Amount
+                                                    </th>
+                                                    <td
+                                                        mat-cell
+                                                        *matCellDef="let housing"
+                                                    >
+                                                        <mat-form-field appearance="fill">
+                                                            <input matInput [value]="housing.amount"/>
+                                                        </mat-form-field>
+                                                    </td>
+                                                </ng-container>
+
+                                                <!-- housing notes column -->
+                                                <ng-container matColumnDef="Notes">
+                                                    <th mat-header-cell *matHeaderCellDef>Notes</th>
+                                                    <td mat-cell *matCellDef="let housing">
+                                                        <mat-form-field appearance="fill">
+                                                            <input matInput [value]="housing.notes"/>
+                                                        </mat-form-field>
+                                                    </td>
+                                                </ng-container>
+
+                                                <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+                                                <tr
+                                                    mat-row
+                                                    *matRowDef="let row; columns: displayedColumns"
+                                                    class="results-noclick-row"
+                                                ></tr>
+                                            </table>
+                                        </div>
+                            </mat-expansion-panel>
+                        </mat-accordion>
+            </mat-expansion-panel>
+            <mat-expansion-panel hideToggle expanded="false">
+                <mat-expansion-panel-header>
+                    <mat-panel-title>
+                    Site Files
+                    </mat-panel-title>
+                </mat-expansion-panel-header>
+            </mat-expansion-panel>
+        </mat-accordion>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+        <div class="detail-section-buttons centered">
+            <button mat-button mat-dialog-close cdkFocusInitial aria-mat-label="Save" type="submit">Save</button>
+            <button mat-button mat-dialog-close cdkFocusInitial aria-mat-label="Cancel">Cancel</button>
+            <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
+        </div>
+    </mat-dialog-actions>
+</form>
+

--- a/src/app/site-edit/site-edit.component.html
+++ b/src/app/site-edit/site-edit.component.html
@@ -200,7 +200,7 @@
                         <mat-form-field appearance="fill">
                             <mat-label>State</mat-label>
                             <mat-select formControlName="state" required (selectionChange)="getCountyList($event.value)">
-                                <mat-option *ngFor="let state of stateList" [value]="state.state_name">
+                                <mat-option *ngFor="let state of stateList" [value]="state.state_abbrev">
                                     {{state.state_name}}
                                 </mat-option>
                             </mat-select>
@@ -376,7 +376,7 @@
                                                     <th mat-header-cell *matHeaderCellDef>Housing Length (ft)</th>
                                                     <td mat-cell *matCellDef="let housing">
                                                         <mat-form-field appearance="fill">
-                                                            <input matInput [value]="housing.length"/>
+                                                            <input matInput [value]="housing.length" (change)="updateHousingAttr($event, housing)"/>
                                                         </mat-form-field>
                                                     </td>
                                                 </ng-container>
@@ -386,7 +386,7 @@
                                                     <th mat-header-cell *matHeaderCellDef>Housing Material</th>
                                                     <td mat-cell *matCellDef="let housing">
                                                         <mat-form-field appearance="fill">
-                                                            <input matInput [value]="housing.material"/>
+                                                            <input matInput [value]="housing.material" (change)="updateHousingAttr($event, housing)"/>
                                                         </mat-form-field>
                                                     </td>
                                                 </ng-container>
@@ -494,42 +494,42 @@
                     </mat-form-field>
                     
                                     <!--Upload Single Image with validations*-->
-                                    <div *ngIf="addFileType === 'New' && siteFiles.filetype_id !== 8">
+                                    <div *ngIf="addFileType === 'New' && siteFiles.FileEntity.filetype_id !== 8">
                                         <label class="custom-file-input-add" for="addFile">
-                                            <p class="required">*</p>
+                                            <p class="required">*</p> {{ siteFiles.FileEntity.name || ' None Chosen' }}
                                         </label>
-                                        <input #upload id="addFile" class="upload-file" type="file" max="500000" [hidden]="true" (click)="saveFileUpload($event)">
+                                        <input #upload id="addFile" class="upload-file" type="file" max="500000" [hidden]="true" (change)="getFileName($event)">
                                     </div>
                                     <br clear="all" />
 
                                     <!--File URL (LINK file)-->
-                                    <div *ngIf="siteFiles.filetype_id === 8">
+                                    <div *ngIf="siteFiles.FileEntity.filetype_id === 8">
                                         <mat-form-field appearance="fill">
                                             <mat-label>File URL</mat-label>
-                                            <input formControlName="name" matInput required [value]="siteFiles.name"/>
+                                            <input formControlName="name" matInput required [value]="siteFiles.FileEntity.name"/>
                                             <mat-icon matSuffix class="info-icon" matTooltip="Please link to persistent URLs or digital object identifier (doi) urls." 
                                             aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>                
                                         </mat-form-field>
                                     </div>
 
                                     <!--Source Name (photo)-->
-                                    <div *ngIf="siteFiles.filetype_id === 1">
+                                    <div *ngIf="siteFiles.FileEntity.filetype_id === 1">
                                         <mat-form-field appearance="fill">
                                             <mat-label>Source Photographer</mat-label>
-                                            <input formControlName="FULLname" matInput required [value]="siteFiles.FULLname"/>           
+                                            <input formControlName="FULLname" matInput required [value]="siteFiles.FileEntity.FULLname"/>           
                                         </mat-form-field>
                                     </div>
 
                                     <!--Source Name (all other)-->
-                                    <div *ngIf="siteFiles.filetype_id  > 2">
+                                    <div *ngIf="siteFiles.FileEntity.filetype_id  > 2">
                                         <mat-form-field appearance="fill">
                                             <mat-label>Source Name</mat-label>
-                                            <input formControlName="FULLname" matInput required [value]="siteFiles.FULLname"/>           
+                                            <input formControlName="FULLname" matInput required [value]="siteFiles.FileEntity.FULLname"/>           
                                         </mat-form-field>
                                     </div>
 
                                     <!--Source Agency* (photo, allOther)-->
-                                    <div *ngIf="siteFiles.filetype_id === 1 || siteFiles.filetype_id > 2">
+                                    <div *ngIf="siteFiles.FileEntity.filetype_id === 1 || siteFiles.FileEntity.filetype_id > 2">
                                         <mat-form-field appearance="fill">
                                             <mat-label>Source Agency</mat-label>
                                             <mat-select required formControlName="agency_id" (selectionChange)="updateAgencyForCaption()">
@@ -541,49 +541,49 @@
                                     </div>
 
                                     <!-- Photo Date* (photo) -->
-                                    <div *ngIf="siteFiles.filetype_id === 1">
+                                    <div *ngIf="siteFiles.FileEntity.filetype_id === 1">
                                         <mat-form-field appearance="fill">
                                             <mat-label>Photo Date</mat-label>
-                                            <input matInput formControlName="photo_date" [value]="siteFiles.photo_date" [matDatepicker]="photoDatePicker" (dateChange)="formatDate($event)" required placeholder="Choose a date">
+                                            <input matInput formControlName="photo_date" [value]="siteFiles.FileEntity.photo_date" [matDatepicker]="photoDatePicker" (dateChange)="formatDate($event)" required placeholder="Choose a date">
                                             <mat-datepicker-toggle matSuffix [for]="photoDatePicker"></mat-datepicker-toggle>
-                                            <mat-datepicker [value]="siteFiles.photo_date" #photoDatePicker></mat-datepicker>
+                                            <mat-datepicker [value]="siteFiles.FileEntity.photo_date" #photoDatePicker></mat-datepicker>
                                         </mat-form-field>
                                     </div>
 
                                     <!-- Date Uploaded* (photo, data, allother) -->
-                                    <div *ngIf="siteFiles.filetype_id > 0">
+                                    <div *ngIf="siteFiles.FileEntity.filetype_id > 0">
                                         <mat-form-field appearance="fill">
                                             <mat-label>Date Uploaded</mat-label>
-                                            <input matInput formControlName="file_date" [value]="siteFiles.file_date" [matDatepicker]="fileDatePicker" required placeholder="Choose a date" (dateChange)="formatDate($event)">
+                                            <input matInput formControlName="file_date" [value]="siteFiles.FileEntity.file_date" [matDatepicker]="fileDatePicker" required placeholder="Choose a date" (dateChange)="formatDate($event)">
                                             <mat-datepicker-toggle matSuffix [for]="fileDatePicker"></mat-datepicker-toggle>
                                             <mat-datepicker #fileDatePicker></mat-datepicker>
                                         </mat-form-field>
                                     </div>
 
                                     <!--Description*(photo, data, allother)-->
-                                    <div *ngIf="siteFiles.filetype_id > 0">
+                                    <div *ngIf="siteFiles.FileEntity.filetype_id > 0">
                                         <mat-form-field appearance="fill">
                                             <mat-label for="description">Description</mat-label>
-                                            <textarea matInput formControlName="description" required id="description" [value]="siteFiles.description"></textarea>
-                                            <mat-icon [hidden]="siteFiles.filetype_id !== 1" matSuffix class="info-icon" matTooltip="Populates in Photo caption below. If a person or people appear in photo include name(s). If non-USGS personnel, ensure consent to publish name in caption is given." 
+                                            <textarea matInput formControlName="description" required id="description" [value]="siteFiles.FileEntity.description"></textarea>
+                                            <mat-icon [hidden]="siteFiles.FileEntity.filetype_id !== 1" matSuffix class="info-icon" matTooltip="Populates in Photo caption below. If a person or people appear in photo include name(s). If non-USGS personnel, ensure consent to publish name in caption is given." 
                                             aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
                                         </mat-form-field>
                                     </div>
 
                                     <!-- This is where Other ends, rest is for Photo -->
                                     <!--Photo Direction (photo)-->
-                                    <div *ngIf="siteFiles.filetype_id === 1">
+                                    <div *ngIf="siteFiles.FileEntity.filetype_id === 1">
                                         <mat-form-field appearance="fill">
                                             <mat-label>Photo Direction</mat-label>
-                                            <input formControlName="photo_direction" matInput [value]="siteFiles.photo_direction"/>           
+                                            <input formControlName="photo_direction" matInput [value]="siteFiles.FileEntity.photo_direction"/>           
                                         </mat-form-field>
                                     </div>
 
                                     <!-- Photo Latitude (photo)-->
-                                    <div *ngIf="siteFiles.filetype_id === 1">
+                                    <div *ngIf="siteFiles.FileEntity.filetype_id === 1">
                                         <mat-form-field appearance="fill">
                                             <mat-label>Photo Latitude (if different)</mat-label>
-                                            <input formControlName="latitude_dd" matInput [value]="siteFiles.latitude_dd"/>           
+                                            <input formControlName="latitude_dd" matInput [value]="siteFiles.FileEntity.latitude_dd"/>           
                                         </mat-form-field>
                                     </div>
                                     <!-- LatDD Validator -->
@@ -595,10 +595,10 @@
                                     </div>
 
                                     <!--Photo Longitude (photo)-->
-                                    <div *ngIf="siteFiles.filetype_id === 1">
+                                    <div *ngIf="siteFiles.FileEntity.filetype_id === 1">
                                         <mat-form-field appearance="fill">
                                             <mat-label>Photo Longitude (if different)</mat-label>
-                                            <input formControlName="longitude_dd" matInput [value]="siteFiles.longitude_dd"/>           
+                                            <input formControlName="longitude_dd" matInput [value]="siteFiles.FileEntity.longitude_dd"/>           
                                         </mat-form-field>
                                     </div>
                                     <!-- LonDD Validator -->
@@ -609,7 +609,7 @@
                                         </div>
                                     </div>
 
-                                    <div *ngIf="siteFiles.filetype_id === 11">
+                                    <div *ngIf="siteFiles.FileEntity.filetype_id === 11">
                                         <label class="form-header" for="Caption">Preview Caption</label>
                                         <div>
                                             <span>
@@ -619,31 +619,43 @@
                                     </div>
 
                                     <!-- associated files -->
-                                    <div *ngIf="addFileType === 'Existing' && siteFiles.filetype_id !== 8">
+                                    <div *ngIf="addFileType === 'Existing' && siteFiles.FileEntity.filetype_id !== 8">
                                         <label class="form-header">Associated File:</label>
                                         <div>
                                             <span *ngIf="fileItemExists">
-                                                <a target="_blank" title="Download File" href="{{fileSource}}">{{siteFiles.name}}</a>
+                                                <a target="_blank" title="Download File" href="{{fileSource}}">{{siteFiles.FileEntity.name}}</a>
                                             </span>
                                             <span *ngIf="!fileItemExists">-- Missing --</span>
                                             <!--ReUpload Single Image with validations*-->
                                             <div *ngIf="!fileItemExists">
-                                                <label class="custom-file-input" for="Upload"></label>
-                                                <input #upload [hidden]="true" id="Upload" type="file" max="500000" file-model="existingFile.File" (click)="saveFileUpload($event)">
+                                                <label class="custom-file-input" for="Upload">
+                                                    <p class="required">*</p> {{ siteFiles.FileEntity.name || ' None Chosen' }}
+                                                </label>
+                                                <input #upload [hidden]="true" id="Upload" type="file" max="500000" file-model="existingFile.File" (change)="getFileName($event)">
+                                                <span *ngIf="fileUploading" class="file-upload-span">
+                                                    Correct File?
+                                                    <button mat-button class="save-btn" *ngIf="fileUploading" type="button" (click)="saveFileUpload()">Upload</button>
+                                                </span>
                                             </div>
                                             <!-- change out the existing fileItem with a different one-->
                                             <div *ngIf="fileItemExists">
                                                 <div>
-                                                    <label class="custom-file-inputChange" for="Upload"></label>
-                                                    <input #upload [hidden]="true" id="Upload" type="file" max="500000" file-model="existingFile.File1" (click)="saveFileUpload($event)">
+                                                    <label class="custom-file-inputChange" for="Upload">
+                                                        <p class="required">*</p> {{ siteFiles.FileEntity.name || ' None Chosen' }}
+                                                    </label>
+                                                    <input #upload [hidden]="true" id="Upload" type="file" max="500000" file-model="existingFile.File1" (change)="getFileName($event)">
                                                 </div>
+                                                <span *ngIf="fileUploading" class="file-upload-span">
+                                                    Correct File?
+                                                    <button mat-button class="save-btn" *ngIf="fileUploading" type="button" (click)="saveFileUpload()">Upload</button>
+                                                </span>
                                             </div>
                                         </div>
                                     </div>
                                     <div [hidden]="siteFileIsUploading" class="file-button-group">
-                                        <button mat-button type="button" class="save-btn" *ngIf="siteFiles.file_id !== null" (click)="saveFile()">Save File</button>
-                                        <button mat-button class="delete-btn" type="button" *ngIf="siteFiles.file_id !== null" (click)="deleteFile()">Delete File</button>
-                                        <button mat-button type="button" class="save-btn" *ngIf="siteFiles.file_id == null" (click)="createFile()">Create File</button>
+                                        <button mat-button type="button" class="save-btn" *ngIf="siteFiles.FileEntity.file_id !== null" (click)="saveFile()">Save File</button>
+                                        <button mat-button class="delete-btn" type="button" *ngIf="siteFiles.FileEntity.file_id !== null" (click)="deleteFile()">Delete File</button>
+                                        <button mat-button type="button" class="save-btn" *ngIf="siteFiles.FileEntity.file_id == null" (click)="createFile()">Create File</button>
                                         <button mat-raised-button style="margin-left: 10px" type="button" (click)="cancelFile()">Close/Cancel File</button>
                                     </div>
                 </form>

--- a/src/app/site-edit/site-edit.component.html
+++ b/src/app/site-edit/site-edit.component.html
@@ -21,18 +21,130 @@
                             <mat-label>Internal Notes</mat-label>
                             <textarea matInput formControlName="site_notes" [value]="site.internal_notes"></textarea>
                         </mat-form-field>
-                        <mat-radio-group id="latLngUnit">
+                        <mat-radio-group id="latLngUnit" [(ngModel)]="latLngUnit" [ngModelOptions]="{standalone: true}" (change)="changeLatLngUnit($event)">
                             <mat-radio-button class="radio-button" value="decdeg">Dec Deg</mat-radio-button>
                             <mat-radio-button class="radio-button" value="dms">DMS</mat-radio-button>
-                        </mat-radio-group>                
-                        <mat-form-field appearance="fill">
-                            <mat-label>Latitude</mat-label>
-                            <input formControlName="latitude_dd" required matInput [value]="site.latitude_dd"/>
-                        </mat-form-field>
-                        <mat-form-field appearance="fill">
-                            <mat-label>Longitude</mat-label>
-                            <input formControlName = "longitude_dd" required matInput [value]="site.longitude_dd"/>
-                        </mat-form-field>
+                        </mat-radio-group>   
+                        <div *ngIf="latLngUnit === 'decdeg'">            
+                            <mat-form-field appearance="fill">
+                                <mat-label>Latitude</mat-label>
+                                <input formControlName="latitude_dd" required matInput [value]="site.latitude_dd"/>
+                            </mat-form-field>
+                            <!-- LatDD Validator -->
+                            <div *ngIf="siteForm.controls.latitude_dd.invalid && (siteForm.controls.latitude_dd.dirty || siteForm.controls.latitude_dd.touched)"
+                                class="alert alert-danger">
+                                <div *ngIf="siteForm.controls.latitude_dd.errors?.['incorrectValue']">
+                                    The latitude must be between 0 and 73.0.
+                                </div>
+                            </div>
+                            <mat-form-field appearance="fill">
+                                <mat-label>Longitude</mat-label>
+                                <input formControlName = "longitude_dd" required matInput [value]="site.longitude_dd"/>
+                            </mat-form-field>
+                            <!-- LonDD Validator -->
+                            <div *ngIf="siteForm.controls.longitude_dd.invalid && (siteForm.controls.longitude_dd.dirty || siteForm.controls.longitude_dd.touched)"
+                                class="alert alert-danger">
+                                <div *ngIf="siteForm.controls.longitude_dd.errors?.['incorrectValue']">
+                                    The longitude must be between -175.0 and -60.0.
+                                </div>
+                            </div>
+                        </div>
+                        <div *ngIf="latLngUnit === 'dms'">
+                            <table>
+                                <tr>
+                                    <td>
+                                        <label>Latitude</label>
+                                    </td>
+                                    <td>
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>Degree</mat-label>
+                                            <input required formControlName="latdeg" matInput [value]="dms.latdeg"/>
+                                        </mat-form-field>
+                                    </td>
+                                    <td>°</td>
+                                    <td>
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>Minute</mat-label>
+                                            <input required formControlName="latmin" matInput [value]="dms.latmin"/>
+                                        </mat-form-field>
+                                    </td>
+                                    <td>′</td>
+                                    <td>
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>Second</mat-label>
+                                            <input required formControlName="latsec" matInput [value]="dms.latsec"/>
+                                        </mat-form-field>
+                                    </td>
+                                    <td>″</td>
+                                </tr>
+                            </table>
+                            <!-- LatDD Validator -->
+                            <div *ngIf="siteForm.controls.latdeg.invalid && (siteForm.controls.latdeg.dirty || siteForm.controls.latdeg.touched)"
+                                class="alert alert-danger">
+                                <div *ngIf="siteForm.controls.latdeg.errors?.['incorrectValue']">
+                                    The latitude must be between -175.0 and -60.0.
+                                </div>
+                            </div>
+                            <div *ngIf="siteForm.controls.latmin.invalid && (siteForm.controls.latmin.dirty || siteForm.controls.latmin.touched)"
+                                class="alert alert-danger">
+                                <div *ngIf="siteForm.controls.latmin.errors?.['incorrectValue']">
+                                    The latitude must be between 0 and 73.
+                                </div>
+                            </div>
+                            <div *ngIf="siteForm.controls.latsec.invalid && (siteForm.controls.latsec.dirty || siteForm.controls.latsec.touched)"
+                                class="alert alert-danger">
+                                <div *ngIf="siteForm.controls.latsec.errors?.['incorrectValue']">
+                                    The latitude must be between 0 and 73.
+                                </div>
+                            </div>
+                            <table>
+                                <tr>
+                                    <td>
+                                        <label>Longitude</label>
+                                    </td>
+                                    <td>
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>Degree</mat-label>
+                                            <input required formControlName="londeg" matInput [value]="dms.londeg"/>
+                                        </mat-form-field>
+                                    </td>
+                                    <td>°</td>
+                                    <td>
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>Minute</mat-label>
+                                            <input required formControlName="lonmin" matInput [value]="dms.lonmin"/>
+                                        </mat-form-field>
+                                    </td>
+                                    <td>′</td>
+                                    <td>
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>Second</mat-label>
+                                            <input required formControlName="lonsec" matInput [value]="dms.lonsec"/>
+                                        </mat-form-field>
+                                    </td>
+                                    <td>″</td>
+                                </tr>
+                            </table>
+                            <!-- LonDD Validator -->
+                            <div *ngIf="siteForm.controls.londeg.invalid && (siteForm.controls.londeg.dirty || siteForm.controls.londeg.touched)"
+                                class="alert alert-danger">
+                                <div *ngIf="siteForm.controls.londeg.errors?.['incorrectValue']">
+                                    The longitude must be between -175.0 and -60.0.
+                                </div>
+                            </div>
+                            <div *ngIf="siteForm.controls.lonmin.invalid && (siteForm.controls.lonmin.dirty || siteForm.controls.lonmin.touched)"
+                                class="alert alert-danger">
+                                <div *ngIf="siteForm.controls.lonmin.errors?.['incorrectValue']">
+                                    The longitude must be between -175.0 and -60.0.
+                                </div>
+                            </div>
+                            <div *ngIf="siteForm.controls.lonsec.invalid && (siteForm.controls.lonsec.dirty || siteForm.controls.lonsec.touched)"
+                                class="alert alert-danger">
+                                <div *ngIf="siteForm.controls.lonsec.errors?.['incorrectValue']">
+                                    The longitude must be between -175.0 and -60.0.
+                                </div>
+                            </div>
+                        </div>
                         <mat-form-field appearance="fill">
                             <mat-label>Horizontal Datum</mat-label>
                             <mat-select formControlName="hdatum" required [(value)]="site.hdatum">
@@ -77,63 +189,63 @@
                             <mat-label>Safety Notes</mat-label>
                             <textarea matInput formControlName="safety_notes" [value]="site.safety_notes"></textarea>
                         </mat-form-field>
+                        <mat-form-field appearance="fill">
+                            <mat-label>Address</mat-label>
+                            <input matInput formControlName="address" [value]="site.address"/>
+                        </mat-form-field>
+                        <mat-form-field appearance="fill">
+                            <mat-label>City</mat-label>
+                            <input matInput formControlName="city" [value]="site.city"/>
+                        </mat-form-field>
+                        <mat-form-field appearance="fill">
+                            <mat-label>State</mat-label>
+                            <mat-select formControlName="state" required (selectionChange)="getCountyList($event.value)">
+                                <mat-option *ngFor="let state of stateList" [value]="state.state_name">
+                                    {{state.state_name}}
+                                </mat-option>
+                            </mat-select>
+                            <mat-icon matSuffix class="info-icon" matTooltip="Used to autogenerate the Site Number." 
+                            aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
+                        </mat-form-field>
+                        <mat-form-field appearance="fill">
+                            <mat-label>Zip</mat-label>
+                            <input matInput formControlName="zip" [value]="site.zip"/>
+                        </mat-form-field>
+                        <mat-form-field appearance="fill">
+                            <mat-label>County</mat-label>
+                            <mat-select formControlName="county" required>
+                                <mat-option *ngFor="let county of countyList" [value]="county.county_name">
+                                    {{county.county_name}}
+                                </mat-option>
+                            </mat-select>
+                        </mat-form-field>
                         <mat-accordion multi="true">
                             <mat-expansion-panel hideToggle>
                             <mat-expansion-panel-header>
                                 <mat-panel-title>
-                                Location Information
+                                Additional Information
                                 </mat-panel-title>
                             </mat-expansion-panel-header>
                                     <mat-form-field appearance="fill">
-                                        <mat-label>Address</mat-label>
-                                        <input matInput formControlName="address" [value]="site.address"/>
-                                    </mat-form-field>
-                                    <mat-form-field appearance="fill">
-                                        <mat-label>City</mat-label>
-                                        <input matInput formControlName="city" [value]="site.city"/>
-                                    </mat-form-field>
-                                    <mat-form-field appearance="fill">
-                                        <mat-label>State</mat-label>
-                                        <mat-select formControlName="state" required [(value)]="site.state" (selectionChange)="getCountyList($event.value)">
-                                            <mat-option *ngFor="let state of stateList" [value]="state.state_name">
-                                                {{state.state_name}}
-                                            </mat-option>
-                                        </mat-select>
-                                        <mat-icon matSuffix class="info-icon" matTooltip="Used to autogenerate the Site Number." 
-                                        aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
-                                    </mat-form-field>
-                                    <mat-form-field appearance="fill">
-                                        <mat-label>Zip</mat-label>
-                                        <input matInput formControlName="zip" [value]="site.zip"/>
-                                    </mat-form-field>
-                                    <mat-form-field appearance="fill">
-                                        <mat-label>County</mat-label>
-                                        <mat-select formControlName="county" required [(value)]="site.county">
-                                            <mat-option *ngFor="let county of countyList" [value]="county.county_name">
-                                                {{county.county_name}}
-                                            </mat-option>
-                                        </mat-select>
-                                        <mat-icon matSuffix class="info-icon" matTooltip="Used to autogenerate the Site Number. Use the Verify Location to populate." 
-                                        aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
-                                    </mat-form-field>
-                                    <mat-form-field appearance="fill">
                                         <mat-label>Priority</mat-label>
-                                        <mat-select>
-
+                                        <mat-select formControlName="priority_id">
+                                            <mat-option *ngFor="let priority of priorityList" [value]="priority.priority_id">
+                                                {{priority.priority_name}}
+                                            </mat-option>
                                         </mat-select>
                                     </mat-form-field>
-                                    <div>Site Location Type in the Network</div>
+                                    <div class="form-header">Site Location Type in the Network</div>
                                     <ul>
                                         <li *ngFor="let type of networkTypes">
-                                        <mat-checkbox [checked]="type.selected" (change)="setSelected($event, type)">
+                                        <mat-checkbox [checked]="type.selected" (change)="setSelectedNetworkType($event, type)">
                                             {{type.network_type_name}}
                                         </mat-checkbox>
                                         </li>
                                     </ul>
-                                    <div>Network Name</div>
+                                    <div class="form-header">Network Name</div>
                                     <ul>
-                                        <li *ngFor="let name of networkNames" (change)="setSelected($event, name)">
-                                        <mat-checkbox [checked]="name.selected">
+                                        <li *ngFor="let name of networkNames">
+                                        <mat-checkbox [checked]="name.selected" (change)="setSelectedNetworkName($event, name)" [disabled]="name.name !== 'Not Defined' && isDisabled">
                                             {{name.name}}
                                         </mat-checkbox>
                                         </li>
@@ -142,44 +254,99 @@
                                         <mat-label>Zone</mat-label>
                                         <input matInput [value]="site.zone"/>
                                     </mat-form-field>
-                                    <mat-checkbox id="sensorAppropriate" [value]="sensorNotAppropriate">
+                                    <mat-checkbox id="sensorAppropriate" [value]="sensorNotAppropriate" [checked]="sensorNotAppropriate" (change)="sensorAppropriateChanged($event)">
                                         Sensor Not Appropriate
                                     </mat-checkbox>
                                     <div>
-                                        <label>Permanent Housing Installed</label>
+                                        <label class="form-header">Permanent Housing Installed</label>
                                         <mat-radio-group class="radio-group" [(value)]="perm_housing_installed" formControlName="is_permanent_housing_installed">
                                             <mat-radio-button class="radio-button" value="Yes">Yes</mat-radio-button>
                                             <mat-radio-button class="radio-button" value="No">No</mat-radio-button>
                                         </mat-radio-group>
                                     </div>
                                     <div>
-                                        Site Creator {{site.memberName}}
+                                        <label class="form-header">Site Creator:</label> {{site.memberName}}
                                     </div>
                                     <div>
                                         <div>
-                                            <label>Landowner Contact</label><mat-icon matSuffix class="info-icon" matTooltip="Do not record information that private citizens have a reasonable expectation of privacy about. No names or phone numbers of private citizens.  Business contact information is acceptable." 
+                                            <label class="form-header">Landowner Contact</label><mat-icon matSuffix class="info-icon" matTooltip="Do not record information that private citizens have a reasonable expectation of privacy about. No names or phone numbers of private citizens.  Business contact information is acceptable." 
                                             aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
                                         </div>
-                                        <button mat-raised-button class="add-button"><mat-icon>add</mat-icon> Add Landowner</button>
+                                        <button mat-raised-button class="add-button" (click)="addLandownerContact()" type="button"><mat-icon>add</mat-icon> Add Landowner</button>
+                                        <form [formGroup]="landownerForm" [hidden]="!hasLandownerContact && !addLandownerCheck">
+                                            <mat-expansion-panel hideToggle expanded="true">
+                                                <mat-expansion-panel-header>
+                                                    <mat-panel-title>
+                                                    Landowner Information
+                                                    </mat-panel-title>
+                                                </mat-expansion-panel-header>
+                                                <mat-card class="mat-elevation-z0 event-alert"><mat-icon class="warning-icon">warning</mat-icon><p>Do not record information that private citizens have a reasonable expectation of privacy about. No names or phone numbers of private citizens. Business contact information is acceptable.</p></mat-card>
+                                                <mat-form-field appearance="fill">
+                                                    <mat-label>First Name</mat-label>
+                                                    <input formControlName="fname" required matInput [value]="landownerContact.fname"/>
+                                                </mat-form-field>
+                                                <mat-form-field appearance="fill">
+                                                    <mat-label>Last Name</mat-label>
+                                                    <input formControlName="lname" matInput [value]="landownerContact.name"/>
+                                                </mat-form-field>
+                                                <mat-form-field appearance="fill">
+                                                    <mat-label>Affiliation/Title</mat-label>
+                                                    <input formControlName="title" matInput [value]="landownerContact.title"/>
+                                                </mat-form-field>
+                                                <mat-checkbox class="site-chx" [value]="useSiteAddress" (click)="useAddressforLO()" >Address same as Site address</mat-checkbox>
+                                                <mat-form-field appearance="fill">
+                                                    <mat-label>Address</mat-label>
+                                                    <input formControlName="fname" matInput [value]="landownerContact.address"/>
+                                                </mat-form-field>
+                                                <mat-form-field appearance="fill">
+                                                    <mat-label>City</mat-label>
+                                                    <input formControlName="city" matInput [value]="landownerContact.city"/>
+                                                </mat-form-field>
+                                                <mat-form-field appearance="fill">
+                                                    <mat-label>State</mat-label>
+                                                    <mat-select formControlName="state">
+                                                        <mat-option *ngFor="let state of stateList" [value]="state.state_name">
+                                                            {{state.state_name}}
+                                                        </mat-option>
+                                                    </mat-select>
+                                                </mat-form-field>
+                                                <mat-form-field appearance="fill">
+                                                    <mat-label>Zip</mat-label>
+                                                    <input formControlName="zip" matInput [value]="landownerContact.zip"/>
+                                                </mat-form-field>
+                                                <mat-form-field appearance="fill">
+                                                    <mat-label>Primary Phone</mat-label>
+                                                    <input formControlName="primaryphone" matInput [value]="landownerContact.primaryphone"/>
+                                                </mat-form-field>
+                                                <mat-form-field appearance="fill">
+                                                    <mat-label>Secondary Phone</mat-label>
+                                                    <input formControlName="secondaryphone" matInput [value]="landownerContact.secondaryphone"/>
+                                                </mat-form-field>
+                                                <mat-form-field appearance="fill">
+                                                    <mat-label>Email</mat-label>
+                                                    <input formControlName="email" matInput [value]="landownerContact.email"/>
+                                                </mat-form-field>
+                                            </mat-expansion-panel>
+                                        </form>
                                     </div>
                                     <div>
-                                        <label>Access Permission Granted</label>
+                                        <label class="form-header">Access Permission Granted</label>
                                         <mat-radio-group class="radio-group" [(value)]="accessGranted" formControlName="access_granted">
                                             <mat-radio-button class="radio-button" value="Yes">Yes</mat-radio-button>
                                             <mat-radio-button class="radio-button" value="No">No</mat-radio-button>
                                             <mat-radio-button class="radio-button" value="Not Needed">Not Needed</mat-radio-button>
                                         </mat-radio-group>
                                     </div>
-                            </mat-expansion-panel>
+                            <!-- </mat-expansion-panel>
                             <mat-expansion-panel hideToggle>
                                 <mat-expansion-panel-header>
                                     <mat-panel-title>
                                     Housing Information
                                     </mat-panel-title>
-                                </mat-expansion-panel-header>
+                                </mat-expansion-panel-header> -->
                                         <mat-form-field appearance="fill">
                                             <mat-label>Site Housing(s)</mat-label>
-                                            <mat-select [value]="siteHousingArray[0].housingType" (selectionChange)="changeTableValue($event.value)">
+                                            <mat-select formControlName="housingType" (selectionChange)="changeTableValue($event.value)" multiple>
                                                 <mat-option *ngFor="let option of siteHousingLookup" [value]="option.type_name">
                                                     {{option.type_name}}
                                                 </mat-option>
@@ -261,6 +428,10 @@
                                             </table>
                                         </div>
                             </mat-expansion-panel>
+                            <div class="site-button-group">
+                                <button class="save-btn" mat-button cdkFocusInitial aria-mat-label="Save" type="submit">Save</button>
+                                <button class="cancel-btn" mat-raised-button mat-dialog-close cdkFocusInitial aria-mat-label="Cancel">Cancel</button>
+                            </div>
                         </mat-accordion>
             </mat-expansion-panel>
             <mat-expansion-panel hideToggle expanded="false">
@@ -268,14 +439,216 @@
                     <mat-panel-title>
                     Site Files
                     </mat-panel-title>
+                    <mat-panel-description>
+                        <mat-icon class="info-header-icon" matTooltip="For general site files only. Please add event-specific files (e.g. HWM photos, field sheets, sensor data files, etc.) by editing the Sensor or HWM sections within this site and uploading files from there ." 
+                        aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
+                    </mat-panel-description>
                 </mat-expansion-panel-header>
+                <button mat-raised-button class="add-button" (click)="addSiteFile()" type="button"><mat-icon>add</mat-icon> Add File</button>
+                <div class="tableContainer" [hidden]="initSiteFiles.length === 0">
+                    <table
+                        mat-table
+                        id="siteFileTable"
+                        [dataSource]="initSiteFiles"
+                        class="mat-elevation-z5"
+                        matSort
+                    >
+
+                        <!-- file name column -->
+                        <ng-container matColumnDef="FileName">
+                            <th mat-header-cell *matHeaderCellDef>File Name</th>
+                            <td mat-cell *matCellDef="let file">
+                                <div>
+                                    {{file.name}}
+                                </div>
+                            </td>
+                        </ng-container>
+
+                        <!-- file date column -->
+                        <ng-container matColumnDef="FileDate">
+                            <th mat-header-cell *matHeaderCellDef>File Date</th>
+                            <td mat-cell *matCellDef="let file">
+                                <div>
+                                    {{file.file_date}}
+                                </div>
+                            </td>
+                        </ng-container>
+
+                        <tr mat-header-row *matHeaderRowDef="displayedFileColumns"></tr>
+                        <tr
+                            mat-row
+                            *matRowDef="let row; columns: displayedFileColumns"
+                            class="file-table"
+                            (click)="showFileEdit(row)"
+                        ></tr>
+                    </table>
+                </div>
+                <form [formGroup]="siteFileForm" [hidden]="!showFileForm">
+                    <mat-form-field appearance="fill">
+                        <mat-label>File Type</mat-label>
+                        <mat-select formControlName="filetype_id" (selectionChange)="getFileTypeSelection($event)">
+                            <mat-option *ngFor="let file of fileTypes" [value]="file.filetype_id">
+                                {{file.filetype}}
+                            </mat-option>
+                        </mat-select>
+                    </mat-form-field>
+                    
+                                    <!--Upload Single Image with validations*-->
+                                    <div *ngIf="addFileType === 'New' && siteFiles.filetype_id !== 8">
+                                        <input #upload class="upload-file" type="file" max="500000">
+                                    </div>
+                                    <br clear="all" />
+
+                                    <!--File URL (LINK file)-->
+                                    <div *ngIf="siteFiles.filetype_id === 8">
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>File URL</mat-label>
+                                            <input formControlName="name" matInput required [value]="siteFiles.name"/>
+                                            <mat-icon matSuffix class="info-icon" matTooltip="Please link to persistent URLs or digital object identifier (doi) urls." 
+                                            aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>                
+                                        </mat-form-field>
+                                    </div>
+
+                                    <!--Source Name (photo)-->
+                                    <div *ngIf="siteFiles.filetype_id === 1">
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>Source Photographer</mat-label>
+                                            <input formControlName="FULLname" matInput required [value]="siteFiles.FULLname"/>           
+                                        </mat-form-field>
+                                    </div>
+
+                                    <!--Source Name (all other)-->
+                                    <div *ngIf="siteFiles.filetype_id  > 2">
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>Source Name</mat-label>
+                                            <input formControlName="FULLname" matInput required [value]="siteFiles.FULLname"/>           
+                                        </mat-form-field>
+                                    </div>
+
+                                    <!--Source Agency* (photo, allOther)-->
+                                    <div *ngIf="siteFiles.filetype_id === 1 || siteFiles.filetype_id > 2">
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>Source Agency</mat-label>
+                                            <mat-select required formControlName="agency_id" (selectionChange)="updateAgencyForCaption($event)">
+                                                <mat-option *ngFor="let a of agencies" [value]="a.agency_id">
+                                                    {{a.agency_name}}
+                                                </mat-option>
+                                            </mat-select>
+                                        </mat-form-field>
+                                    </div>
+
+                                    <!-- Photo Date* (photo) -->
+                                    <div *ngIf="siteFiles.filetype_id === 1">
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>Photo Date</mat-label>
+                                            <input matInput formControlName="photo_date" [value]="siteFiles.photo_date" [matDatepicker]="photoDatePicker" (dateChange)="formatDate($event)" required placeholder="Choose a date">
+                                            <mat-datepicker-toggle matSuffix [for]="photoDatePicker"></mat-datepicker-toggle>
+                                            <mat-datepicker [value]="siteFiles.photo_date" #photoDatePicker></mat-datepicker>
+                                        </mat-form-field>
+                                    </div>
+
+                                    <!-- Date Uploaded* (photo, data, allother) -->
+                                    <div *ngIf="siteFiles.filetype_id > 0">
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>Date Uploaded</mat-label>
+                                            <input matInput formControlName="file_date" [value]="siteFiles.file_date" [matDatepicker]="fileDatePicker" required placeholder="Choose a date" (dateChange)="formatDate($event)">
+                                            <mat-datepicker-toggle matSuffix [for]="fileDatePicker"></mat-datepicker-toggle>
+                                            <mat-datepicker #fileDatePicker></mat-datepicker>
+                                        </mat-form-field>
+                                    </div>
+
+                                    <!--Description*(photo, data, allother)-->
+                                    <div *ngIf="siteFiles.filetype_id > 0">
+                                        <mat-form-field appearance="fill">
+                                            <mat-label for="description">Description</mat-label>
+                                            <textarea matInput formControlName="description" required id="description" [value]="siteFiles.description"></textarea>
+                                            <mat-icon [hidden]="siteFiles.filetype_id !== 1" matSuffix class="info-icon" matTooltip="Populates in Photo caption below. If a person or people appear in photo include name(s). If non-USGS personnel, ensure consent to publish name in caption is given." 
+                                            aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
+                                        </mat-form-field>
+                                    </div>
+
+                                    <!-- This is where Other ends, rest is for Photo -->
+                                    <!--Photo Direction (photo)-->
+                                    <div *ngIf="siteFiles.filetype_id === 1">
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>Photo Direction</mat-label>
+                                            <input formControlName="photo_direction" matInput [value]="siteFiles.photo_direction"/>           
+                                        </mat-form-field>
+                                    </div>
+
+                                    <!-- Photo Latitude (photo)-->
+                                    <div *ngIf="siteFiles.filetype_id === 1">
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>Photo Latitude (if different)</mat-label>
+                                            <input formControlName="latitude_dd" matInput [value]="siteFiles.latitude_dd"/>           
+                                        </mat-form-field>
+                                    </div>
+                                    <!-- LatDD Validator -->
+                                    <div *ngIf="siteFileForm.controls.latitude_dd.invalid && (siteFileForm.controls.latitude_dd.dirty || siteFileForm.controls.latitude_dd.touched)"
+                                        class="alert alert-danger">
+                                        <div *ngIf="siteFileForm.controls.latitude_dd.errors?.['incorrectValue']">
+                                            The latitude must be between 0 and 73.0.
+                                        </div>
+                                    </div>
+
+                                    <!--Photo Longitude (photo)-->
+                                    <div *ngIf="siteFiles.filetype_id === 1">
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>Photo Longitude (if different)</mat-label>
+                                            <input formControlName="longitude_dd" matInput [value]="siteFiles.longitude_dd"/>           
+                                        </mat-form-field>
+                                    </div>
+                                    <!-- LonDD Validator -->
+                                    <div *ngIf="siteFileForm.controls.longitude_dd.invalid && (siteFileForm.controls.longitude_dd.dirty || siteFileForm.controls.longitude_dd.touched)"
+                                        class="alert alert-danger">
+                                        <div *ngIf="siteFileForm.controls.longitude_dd.errors?.['incorrectValue']">
+                                            The longitude must be between -175.0 and -60.0.
+                                        </div>
+                                    </div>
+
+                                    <div *ngIf="siteFiles.filetype_id === 11">
+                                        <label class="form-header" for="Caption">Preview Caption</label>
+                                        <div>
+                                            <span>
+                                                Photo of {{siteFileForm.value.description || ' (Description HERE) '}} at {{siteForm.value.site_description}}, {{siteForm.value.county}}, {{siteForm.value.state}}, {{formattedPhotoDate || ' Date taken HERE '}}. Photograph by {{siteFileForm.value.FULLname || ' Source Name HERE ' }}, {{agencyNameForCap || ' Agency HERE '}}.
+                                            </span>
+                                        </div>
+                                    </div>
+
+                                    <!-- associated files -->
+                                    <div *ngIf="addFileType === 'Existing' && siteFiles.filetype_id !== 8">
+                                        <label class="form-header">Associated File:</label>
+                                        <div>
+                                            <span *ngIf="fileItemExists">
+                                                <a target="_blank" title="Download File" href="{{fileSource}}">{{siteFiles.name}}</a>
+                                            </span>
+                                            <span *ngIf="!fileItemExists">-- Missing --</span>
+                                            <!--ReUpload Single Image with validations*-->
+                                            <div *ngIf="!fileItemExists">
+                                                <!-- <label for="Upload"></label> -->
+                                                <input #upload id="Upload" type="file" max="500000" file-model="existingFile.File" (click)="saveFileUpload($event)">
+                                            </div>
+                                            <!-- change out the existing fileItem with a different one-->
+                                            <div *ngIf="fileItemExists">
+                                                <div>
+                                                    <input #upload id="Upload" type="file" max="500000" file-model="existingFile.File1" (click)="saveFileUpload($event)">
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div [hidden]="siteFileIsUploading" class="file-button-group">
+                                        <button mat-button type="button" class="save-btn" *ngIf="siteFiles.file_id !== null" (click)="saveFile()">Save File</button>
+                                        <button mat-button class="delete-btn" type="button" *ngIf="siteFiles.file_id !== null" (click)="deleteFile()">Delete File</button>
+                                        <button mat-button type="button" class="save-btn" *ngIf="siteFiles.file_id == null" (click)="createFile()">Create File</button>
+                                        <button mat-raised-button style="margin-left: 10px" type="button" (click)="cancelFile()">Close/Cancel File</button>
+                                    </div>
+                </form>
             </mat-expansion-panel>
         </mat-accordion>
     </mat-dialog-content>
     <mat-dialog-actions align="end">
         <div class="detail-section-buttons centered">
-            <button mat-button mat-dialog-close cdkFocusInitial aria-mat-label="Save" type="submit">Save</button>
-            <button mat-button mat-dialog-close cdkFocusInitial aria-mat-label="Cancel">Cancel</button>
+            <button mat-raised-button mat-dialog-close cdkFocusInitial aria-mat-label="Cancel">Cancel</button>
             <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
         </div>
     </mat-dialog-actions>

--- a/src/app/site-edit/site-edit.component.html
+++ b/src/app/site-edit/site-edit.component.html
@@ -1,6 +1,6 @@
 <h2 mat-dialog-title>
     Site
-    <button class="close-button" mat-button [mat-dialog-close]="returnData" aria-mat-label="Exit"><mat-icon>close</mat-icon></button>
+    <button class="close-button" mat-button [mat-dialog-close]="returnData" aria-label="Exit"><mat-icon>close</mat-icon></button>
 </h2>
 <div [hidden]="!loading" class="loading">
     <mat-spinner style="margin:0 auto; top: 50%" mode="indeterminate" diameter="20"></mat-spinner>
@@ -16,13 +16,13 @@
                 </mat-expansion-panel-header>
                         <mat-form-field appearance="fill">
                             <mat-label for="description">Site Description</mat-label>
-                            <textarea matInput formControlName="site_description" required id="description" [value]="site.description"></textarea>
+                            <textarea aria-label="Site Description" matInput formControlName="site_description" required id="description" [value]="site.description"></textarea>
                             <mat-icon matSuffix class="info-icon" matTooltip="Brief description of the site area." 
                             aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
                         </mat-form-field>
                         <mat-form-field appearance="fill">
                             <mat-label>Internal Notes</mat-label>
-                            <textarea matInput formControlName="site_notes" [value]="site.internal_notes"></textarea>
+                            <textarea aria-label="Internal Notes" matInput formControlName="site_notes" [value]="site.internal_notes"></textarea>
                         </mat-form-field>
                         <mat-radio-group id="latLngUnit" [(ngModel)]="latLngUnit" [ngModelOptions]="{standalone: true}" (change)="changeLatLngUnit($event)">
                             <mat-radio-button class="radio-button" value="decdeg">Dec Deg</mat-radio-button>
@@ -31,7 +31,7 @@
                         <div *ngIf="latLngUnit === 'decdeg'">            
                             <mat-form-field appearance="fill">
                                 <mat-label>Latitude</mat-label>
-                                <input formControlName="latitude_dd" required matInput [value]="site.latitude_dd"/>
+                                <input aria-label="Latitude" formControlName="latitude_dd" required matInput [value]="site.latitude_dd"/>
                             </mat-form-field>
                             <!-- LatDD Validator -->
                             <div *ngIf="siteForm.controls.latitude_dd.invalid && (siteForm.controls.latitude_dd.dirty || siteForm.controls.latitude_dd.touched)"
@@ -42,7 +42,7 @@
                             </div>
                             <mat-form-field appearance="fill">
                                 <mat-label>Longitude</mat-label>
-                                <input formControlName = "longitude_dd" required matInput [value]="site.longitude_dd"/>
+                                <input aria-label="Longitude" formControlName = "longitude_dd" required matInput [value]="site.longitude_dd"/>
                             </mat-form-field>
                             <!-- LonDD Validator -->
                             <div *ngIf="siteForm.controls.longitude_dd.invalid && (siteForm.controls.longitude_dd.dirty || siteForm.controls.longitude_dd.touched)"
@@ -61,21 +61,21 @@
                                     <td>
                                         <mat-form-field appearance="fill">
                                             <mat-label>Degree</mat-label>
-                                            <input required formControlName="latdeg" matInput [value]="dms.latdeg"/>
+                                            <input aria-label="Degree" required formControlName="latdeg" matInput [value]="dms.latdeg"/>
                                         </mat-form-field>
                                     </td>
                                     <td>°</td>
                                     <td>
                                         <mat-form-field appearance="fill">
                                             <mat-label>Minute</mat-label>
-                                            <input required formControlName="latmin" matInput [value]="dms.latmin"/>
+                                            <input aria-label="Minute" required formControlName="latmin" matInput [value]="dms.latmin"/>
                                         </mat-form-field>
                                     </td>
                                     <td>′</td>
                                     <td>
                                         <mat-form-field appearance="fill">
                                             <mat-label>Second</mat-label>
-                                            <input required formControlName="latsec" matInput [value]="dms.latsec"/>
+                                            <input aria-label="Second" required formControlName="latsec" matInput [value]="dms.latsec"/>
                                         </mat-form-field>
                                     </td>
                                     <td>″</td>
@@ -108,21 +108,21 @@
                                     <td>
                                         <mat-form-field appearance="fill">
                                             <mat-label>Degree</mat-label>
-                                            <input required formControlName="londeg" matInput [value]="dms.londeg"/>
+                                            <input aria-label="Degree" required formControlName="londeg" matInput [value]="dms.londeg"/>
                                         </mat-form-field>
                                     </td>
                                     <td>°</td>
                                     <td>
                                         <mat-form-field appearance="fill">
                                             <mat-label>Minute</mat-label>
-                                            <input required formControlName="lonmin" matInput [value]="dms.lonmin"/>
+                                            <input aria-label="Minute" required formControlName="lonmin" matInput [value]="dms.lonmin"/>
                                         </mat-form-field>
                                     </td>
                                     <td>′</td>
                                     <td>
                                         <mat-form-field appearance="fill">
                                             <mat-label>Second</mat-label>
-                                            <input required formControlName="lonsec" matInput [value]="dms.lonsec"/>
+                                            <input aria-label="Second" required formControlName="lonsec" matInput [value]="dms.lonsec"/>
                                         </mat-form-field>
                                     </td>
                                     <td>″</td>
@@ -150,7 +150,7 @@
                         </div>
                         <mat-form-field appearance="fill">
                             <mat-label>Horizontal Datum</mat-label>
-                            <mat-select formControlName="hdatum_id" required>
+                            <mat-select aria-label="Horizontal Datum" formControlName="hdatum_id" required>
                                 <mat-option *ngFor="let datum of hDatums" [value]="datum.datum_id">
                                 {{datum.datum_name}}
                                 </mat-option>
@@ -158,7 +158,7 @@
                         </mat-form-field>
                         <mat-form-field appearance="fill">
                             <mat-label>Horizontal Collection Method</mat-label>
-                            <mat-select formControlName="hcollect_method_id" required [(value)]="site.hcollect_method_id">
+                            <mat-select aria-label="Horizontal Collection Method" formControlName="hcollect_method_id" required [(value)]="site.hcollect_method_id">
                                 <mat-option *ngFor="let method of hMethods" [value]="method.hcollect_method_id">
                                 {{method.hcollect_method}}
                                 </mat-option>
@@ -166,43 +166,43 @@
                         </mat-form-field>
                         <mat-form-field appearance="fill">
                             <mat-label>Waterbody</mat-label>
-                            <input formControlName="waterbody" required matInput [value]="site.waterbody"/>
+                            <input aria-label="Waterbody" formControlName="waterbody" required matInput [value]="site.waterbody"/>
                             <mat-icon matSuffix class="info-icon" matTooltip="Required by NWIS.  Can be listed as 'Unknown' or 'Atlantic Ocean'" 
                             aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
                             <mat-hint>e.g. Atlantic Ocean</mat-hint>
                         </mat-form-field>
                         <mat-form-field appearance="fill">
                             <mat-label>Drainage Area</mat-label>
-                            <input formControlName="drainage_area_sqmi" matInput [value]="site.drainage_area"/>
+                            <input aria-label="Drainage Area" formControlName="drainage_area_sqmi" matInput [value]="site.drainage_area"/>
                         </mat-form-field>
                         <mat-form-field appearance="fill">
                             <mat-label>Station ID for USGS Gage</mat-label>
-                            <input matInput formControlName="usgs_sid" [value]="site.usgs_id"/>
+                            <input aria-label="Station ID for USGS Gage" matInput formControlName="usgs_sid" [value]="site.usgs_id"/>
                         </mat-form-field>
                         <mat-form-field appearance="fill">
                             <mat-label>Station ID for NOAA Gage</mat-label>
-                            <input matInput formControlName="noaa_sid" [value]="site.noaa_id"/>
+                            <input aria-label="Station ID for NOAA Gage" matInput formControlName="noaa_sid" [value]="site.noaa_id"/>
                         </mat-form-field>
                         <mat-form-field appearance="fill">
                             <mat-label>Other Station ID</mat-label>
-                            <input matInput formControlName="other_sid" [value]="site.other_id"/>
+                            <input aria-label="Other Station ID" matInput formControlName="other_sid" [value]="site.other_id"/>
                             <mat-hint>Please add details in the Site Description</mat-hint>
                         </mat-form-field>
                         <mat-form-field appearance="fill">
                             <mat-label>Safety Notes</mat-label>
-                            <textarea matInput formControlName="safety_notes" [value]="site.safety_notes"></textarea>
+                            <textarea aria-label="Safety Notes" matInput formControlName="safety_notes" [value]="site.safety_notes"></textarea>
                         </mat-form-field>
                         <mat-form-field appearance="fill">
                             <mat-label>Address</mat-label>
-                            <input matInput formControlName="address" [value]="site.address"/>
+                            <input aria-label="Address" matInput formControlName="address" [value]="site.address"/>
                         </mat-form-field>
                         <mat-form-field appearance="fill">
                             <mat-label>City</mat-label>
-                            <input matInput formControlName="city" [value]="site.city"/>
+                            <input aria-label="City" matInput formControlName="city" [value]="site.city"/>
                         </mat-form-field>
                         <mat-form-field appearance="fill">
                             <mat-label>State</mat-label>
-                            <mat-select formControlName="state" required (selectionChange)="getCountyList($event.value)">
+                            <mat-select aria-label="State" formControlName="state" required (selectionChange)="getCountyList($event.value)">
                                 <mat-option *ngFor="let state of stateList" [value]="state.state_abbrev">
                                     {{state.state_name}}
                                 </mat-option>
@@ -212,11 +212,11 @@
                         </mat-form-field>
                         <mat-form-field appearance="fill">
                             <mat-label>Zip</mat-label>
-                            <input matInput formControlName="zip" [value]="site.zip"/>
+                            <input aria-label="Zip" matInput formControlName="zip" [value]="site.zip"/>
                         </mat-form-field>
                         <mat-form-field appearance="fill">
                             <mat-label>County</mat-label>
-                            <mat-select formControlName="county" required>
+                            <mat-select aria-label="County" formControlName="county" required>
                                 <mat-option *ngFor="let county of countyList" [value]="county.county_name">
                                     {{county.county_name}}
                                 </mat-option>
@@ -231,7 +231,7 @@
                             </mat-expansion-panel-header>
                                     <mat-form-field appearance="fill">
                                         <mat-label>Priority</mat-label>
-                                        <mat-select formControlName="priority_id">
+                                        <mat-select aria-label="Priority" formControlName="priority_id">
                                             <mat-option *ngFor="let priority of priorityList" [value]="priority.priority_id">
                                                 {{priority.priority_name}}
                                             </mat-option>
@@ -255,7 +255,7 @@
                                     </ul>
                                     <mat-form-field appearance="fill">
                                         <mat-label>Zone</mat-label>
-                                        <input matInput [value]="site.zone"/>
+                                        <input aria-label="Zone" matInput [value]="site.zone"/>
                                     </mat-form-field>
                                     <mat-checkbox id="sensorAppropriate" [value]="sensorNotAppropriate" [checked]="sensorNotAppropriate" (change)="sensorAppropriateChanged($event)">
                                         Sensor Not Appropriate
@@ -286,28 +286,28 @@
                                                 <mat-card class="mat-elevation-z0 event-alert"><mat-icon class="warning-icon">warning</mat-icon><p>Do not record information that private citizens have a reasonable expectation of privacy about. No names or phone numbers of private citizens. Business contact information is acceptable.</p></mat-card>
                                                 <mat-form-field appearance="fill">
                                                     <mat-label>First Name</mat-label>
-                                                    <input formControlName="fname" required matInput [value]="landownerContact.fname"/>
+                                                    <input aria-label="First Name" formControlName="fname" required matInput [value]="landownerContact.fname"/>
                                                 </mat-form-field>
                                                 <mat-form-field appearance="fill">
                                                     <mat-label>Last Name</mat-label>
-                                                    <input formControlName="lname" matInput [value]="landownerContact.name"/>
+                                                    <input aria-label="Last Name" formControlName="lname" matInput [value]="landownerContact.name"/>
                                                 </mat-form-field>
                                                 <mat-form-field appearance="fill">
                                                     <mat-label>Affiliation/Title</mat-label>
-                                                    <input formControlName="title" matInput [value]="landownerContact.title"/>
+                                                    <input aria-label="Affiliation/Title" formControlName="title" matInput [value]="landownerContact.title"/>
                                                 </mat-form-field>
                                                 <mat-checkbox class="site-chx" [value]="useSiteAddress" (click)="useAddressforLO()" >Address same as Site address</mat-checkbox>
                                                 <mat-form-field appearance="fill">
                                                     <mat-label>Address</mat-label>
-                                                    <input formControlName="address" matInput [value]="landownerContact.address"/>
+                                                    <input aria-label="Address" formControlName="address" matInput [value]="landownerContact.address"/>
                                                 </mat-form-field>
                                                 <mat-form-field appearance="fill">
                                                     <mat-label>City</mat-label>
-                                                    <input formControlName="city" matInput [value]="landownerContact.city"/>
+                                                    <input aria-label="City" formControlName="city" matInput [value]="landownerContact.city"/>
                                                 </mat-form-field>
                                                 <mat-form-field appearance="fill">
                                                     <mat-label>State</mat-label>
-                                                    <mat-select formControlName="state">
+                                                    <mat-select aria-label="State" formControlName="state">
                                                         <mat-option *ngFor="let state of stateList" [value]="state.state_name">
                                                             {{state.state_name}}
                                                         </mat-option>
@@ -315,19 +315,19 @@
                                                 </mat-form-field>
                                                 <mat-form-field appearance="fill">
                                                     <mat-label>Zip</mat-label>
-                                                    <input formControlName="zip" matInput [value]="landownerContact.zip"/>
+                                                    <input aria-label="Zip" formControlName="zip" matInput [value]="landownerContact.zip"/>
                                                 </mat-form-field>
                                                 <mat-form-field appearance="fill">
                                                     <mat-label>Primary Phone</mat-label>
-                                                    <input formControlName="primaryphone" matInput [value]="landownerContact.primaryphone"/>
+                                                    <input aria-label="Primary Phone" formControlName="primaryphone" matInput [value]="landownerContact.primaryphone"/>
                                                 </mat-form-field>
                                                 <mat-form-field appearance="fill">
                                                     <mat-label>Secondary Phone</mat-label>
-                                                    <input formControlName="secondaryphone" matInput [value]="landownerContact.secondaryphone"/>
+                                                    <input aria-label="Secondary Phone" formControlName="secondaryphone" matInput [value]="landownerContact.secondaryphone"/>
                                                 </mat-form-field>
                                                 <mat-form-field appearance="fill">
                                                     <mat-label>Email</mat-label>
-                                                    <input formControlName="email" matInput [value]="landownerContact.email"/>
+                                                    <input aria-label="Email" formControlName="email" matInput [value]="landownerContact.email"/>
                                                 </mat-form-field>
                                             </mat-expansion-panel>
                                         </form>
@@ -349,7 +349,7 @@
                                 </mat-expansion-panel-header> -->
                                         <mat-form-field appearance="fill">
                                             <mat-label>Site Housing(s)</mat-label>
-                                            <mat-select formControlName="housingType" (selectionChange)="changeTableValue($event.value)" multiple>
+                                            <mat-select aria-label="Site Housings" formControlName="housingType" (selectionChange)="changeTableValue($event.value)" multiple>
                                                 <mat-option *ngFor="let option of siteHousingLookup" [value]="option.type_name">
                                                     {{option.type_name}}
                                                 </mat-option>
@@ -433,8 +433,8 @@
                                         </div>
                             </mat-expansion-panel>
                             <div class="site-button-group">
-                                <button class="save-btn" mat-button cdkFocusInitial aria-mat-label="Save" type="submit">Save</button>
-                                <button class="cancel-btn" mat-raised-button mat-dialog-close cdkFocusInitial aria-mat-label="Cancel">Cancel</button>
+                                <button class="save-btn" mat-button cdkFocusInitial aria-label="Save" type="submit">Save</button>
+                                <button class="cancel-btn" mat-raised-button mat-dialog-close cdkFocusInitial aria-label="Cancel">Cancel</button>
                             </div>
                         </mat-accordion>
             </mat-expansion-panel>
@@ -490,7 +490,7 @@
                 <form [formGroup]="siteFileForm" [hidden]="!showFileForm">
                     <mat-form-field appearance="fill">
                         <mat-label>File Type</mat-label>
-                        <mat-select formControlName="filetype_id" (selectionChange)="getFileTypeSelection($event)">
+                        <mat-select aria-label="File Type" formControlName="filetype_id" (selectionChange)="getFileTypeSelection($event)">
                             <mat-option *ngFor="let file of fileTypes" [value]="file.filetype_id">
                                 {{file.filetype}}
                             </mat-option>
@@ -510,7 +510,7 @@
                                     <div *ngIf="siteFiles.FileEntity.filetype_id === 8">
                                         <mat-form-field appearance="fill">
                                             <mat-label>File URL</mat-label>
-                                            <input formControlName="name" matInput [value]="siteFiles.FileEntity.name"/>
+                                            <input aria-label="File URL" formControlName="name" matInput [value]="siteFiles.FileEntity.name"/>
                                             <mat-icon matSuffix class="info-icon" matTooltip="Please link to persistent URLs or digital object identifier (doi) urls." 
                                             aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>                
                                         </mat-form-field>
@@ -520,7 +520,7 @@
                                     <div *ngIf="siteFiles.FileEntity.filetype_id === 1">
                                         <mat-form-field appearance="fill">
                                             <mat-label>Source Photographer</mat-label>
-                                            <input formControlName="FULLname" matInput required [value]="siteFiles.FileEntity.FULLname"/>           
+                                            <input aria-label="Source Photographer" formControlName="FULLname" matInput required [value]="siteFiles.FileEntity.FULLname"/>           
                                         </mat-form-field>
                                     </div>
 
@@ -528,7 +528,7 @@
                                     <div *ngIf="siteFiles.FileEntity.filetype_id  > 2">
                                         <mat-form-field appearance="fill">
                                             <mat-label>Source Name</mat-label>
-                                            <input formControlName="FULLname" matInput required [value]="siteFiles.FileEntity.FULLname"/>           
+                                            <input aria-label="Source Name" formControlName="FULLname" matInput required [value]="siteFiles.FileEntity.FULLname"/>           
                                         </mat-form-field>
                                     </div>
 
@@ -536,7 +536,7 @@
                                     <div *ngIf="siteFiles.FileEntity.filetype_id === 1 || siteFiles.FileEntity.filetype_id > 2">
                                         <mat-form-field appearance="fill">
                                             <mat-label>Source Agency</mat-label>
-                                            <mat-select required formControlName="agency_id" (selectionChange)="updateAgencyForCaption()">
+                                            <mat-select aria-label="Source Agency" required formControlName="agency_id" (selectionChange)="updateAgencyForCaption()">
                                                 <mat-option *ngFor="let a of agencies" [value]="a.agency_id">
                                                     {{a.agency_name}}
                                                 </mat-option>
@@ -548,7 +548,7 @@
                                     <div *ngIf="siteFiles.FileEntity.filetype_id === 1">
                                         <mat-form-field appearance="fill">
                                             <mat-label>Photo Date</mat-label>
-                                            <input matInput formControlName="photo_date" [value]="siteFiles.FileEntity.photo_date" [matDatepicker]="photoDatePicker" (dateChange)="formatDate($event)" required placeholder="Choose a date">
+                                            <input aria-label="Photo Date" matInput formControlName="photo_date" [value]="siteFiles.FileEntity.photo_date" [matDatepicker]="photoDatePicker" (dateChange)="formatDate($event)" required placeholder="Choose a date">
                                             <mat-datepicker-toggle matSuffix [for]="photoDatePicker"></mat-datepicker-toggle>
                                             <mat-datepicker [value]="siteFiles.FileEntity.photo_date" #photoDatePicker></mat-datepicker>
                                         </mat-form-field>
@@ -558,7 +558,7 @@
                                     <div *ngIf="siteFiles.FileEntity.filetype_id > 0">
                                         <mat-form-field appearance="fill">
                                             <mat-label>Date Uploaded</mat-label>
-                                            <input matInput formControlName="file_date" [value]="siteFiles.FileEntity.file_date" [matDatepicker]="fileDatePicker" required placeholder="Choose a date" (dateChange)="formatDate($event)">
+                                            <input aria-label="Date Uploaded" matInput formControlName="file_date" [value]="siteFiles.FileEntity.file_date" [matDatepicker]="fileDatePicker" required placeholder="Choose a date" (dateChange)="formatDate($event)">
                                             <mat-datepicker-toggle matSuffix [for]="fileDatePicker"></mat-datepicker-toggle>
                                             <mat-datepicker #fileDatePicker></mat-datepicker>
                                         </mat-form-field>
@@ -568,7 +568,7 @@
                                     <div *ngIf="siteFiles.FileEntity.filetype_id > 0">
                                         <mat-form-field appearance="fill">
                                             <mat-label for="description">Description</mat-label>
-                                            <textarea matInput formControlName="description" required id="description" [value]="siteFiles.FileEntity.description"></textarea>
+                                            <textarea aria-label="Description" matInput formControlName="description" required id="description" [value]="siteFiles.FileEntity.description"></textarea>
                                             <mat-icon [hidden]="siteFiles.FileEntity.filetype_id !== 1" matSuffix class="info-icon" matTooltip="Populates in Photo caption below. If a person or people appear in photo include name(s). If non-USGS personnel, ensure consent to publish name in caption is given." 
                                             aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
                                         </mat-form-field>
@@ -579,7 +579,7 @@
                                     <div *ngIf="siteFiles.FileEntity.filetype_id === 1">
                                         <mat-form-field appearance="fill">
                                             <mat-label>Photo Direction</mat-label>
-                                            <input formControlName="photo_direction" matInput [value]="siteFiles.FileEntity.photo_direction"/>           
+                                            <input aria-label="Photo Direction" formControlName="photo_direction" matInput [value]="siteFiles.FileEntity.photo_direction"/>           
                                         </mat-form-field>
                                     </div>
 
@@ -587,7 +587,7 @@
                                     <div *ngIf="siteFiles.FileEntity.filetype_id === 1">
                                         <mat-form-field appearance="fill">
                                             <mat-label>Photo Latitude (if different)</mat-label>
-                                            <input formControlName="latitude_dd" matInput [value]="siteFiles.FileEntity.latitude_dd"/>           
+                                            <input aria-label="Photo Latitude (if different)" formControlName="latitude_dd" matInput [value]="siteFiles.FileEntity.latitude_dd"/>           
                                         </mat-form-field>
                                     </div>
                                     <!-- LatDD Validator -->
@@ -602,7 +602,7 @@
                                     <div *ngIf="siteFiles.FileEntity.filetype_id === 1">
                                         <mat-form-field appearance="fill">
                                             <mat-label>Photo Longitude (if different)</mat-label>
-                                            <input formControlName="longitude_dd" matInput [value]="siteFiles.FileEntity.longitude_dd"/>           
+                                            <input aria-label="Photo longitude (if different)" formControlName="longitude_dd" matInput [value]="siteFiles.FileEntity.longitude_dd"/>           
                                         </mat-form-field>
                                     </div>
                                     <!-- LonDD Validator -->
@@ -638,7 +638,7 @@
                                                 <input #upload [hidden]="true" id="Upload" type="file" max="500000" file-model="existingFile.File" (change)="getFileName($event)">
                                                 <span *ngIf="fileUploading" class="file-upload-span">
                                                     Correct File?
-                                                    <button mat-button class="save-btn" *ngIf="fileUploading" type="button" (click)="saveFileUpload()">Upload</button>
+                                                    <button aria-label="Upload" mat-button class="save-btn" *ngIf="fileUploading" type="button" (click)="saveFileUpload()">Upload</button>
                                                 </span>
                                             </div>
                                             <!-- change out the existing fileItem with a different one-->
@@ -651,16 +651,16 @@
                                                 </div>
                                                 <span *ngIf="fileUploading" class="file-upload-span">
                                                     Correct File?
-                                                    <button mat-button class="save-btn" *ngIf="fileUploading" type="button" (click)="saveFileUpload()">Upload</button>
+                                                    <button aria-label="Is this file correct?" mat-button class="save-btn" *ngIf="fileUploading" type="button" (click)="saveFileUpload()">Upload</button>
                                                 </span>
                                             </div>
                                         </div>
                                     </div>
                                     <div [hidden]="siteFileIsUploading" class="file-button-group">
-                                        <button mat-button type="button" class="save-btn" *ngIf="siteFiles.FileEntity.file_id !== null" (click)="saveFile()">Save File</button>
-                                        <button mat-button class="delete-btn" type="button" *ngIf="siteFiles.FileEntity.file_id !== null" (click)="deleteFile()">Delete File</button>
-                                        <button mat-button type="button" class="save-btn" *ngIf="siteFiles.FileEntity.file_id == null" (click)="createFile()">Create File</button>
-                                        <button mat-raised-button style="margin-left: 10px" type="button" (click)="cancelFile()">Close/Cancel File</button>
+                                        <button aria-label="Save File" mat-button type="button" class="save-btn" *ngIf="siteFiles.FileEntity.file_id !== null" (click)="saveFile()">Save File</button>
+                                        <button aria-label="Delete File" mat-button class="delete-btn" type="button" *ngIf="siteFiles.FileEntity.file_id !== null" (click)="deleteFile()">Delete File</button>
+                                        <button aria-label="Create File" mat-button type="button" class="save-btn" *ngIf="siteFiles.FileEntity.file_id == null" (click)="createFile()">Create File</button>
+                                        <button aria-label="Close or Cancel File" mat-raised-button style="margin-left: 10px" type="button" (click)="cancelFile()">Close/Cancel File</button>
                                     </div>
                 </form>
             </mat-expansion-panel>
@@ -668,7 +668,7 @@
     </mat-dialog-content>
     <mat-dialog-actions align="end">
         <div class="detail-section-buttons centered">
-            <button mat-raised-button [mat-dialog-close]="returnData" cdkFocusInitial aria-mat-label="Close">Close</button>
+            <button mat-raised-button [mat-dialog-close]="returnData" cdkFocusInitial aria-label="Close">Close</button>
             <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
         </div>
     </mat-dialog-actions>

--- a/src/app/site-edit/site-edit.component.html
+++ b/src/app/site-edit/site-edit.component.html
@@ -1,7 +1,10 @@
 <h2 mat-dialog-title>
     Site
-    <!-- <button class="close-button" mat-button mat-dialog-close aria-mat-label="Exit"><mat-icon>close</mat-icon></button> -->
+    <button class="close-button" mat-button [mat-dialog-close]="returnData" aria-mat-label="Exit"><mat-icon>close</mat-icon></button>
 </h2>
+<div [hidden]="!loading" class="loading">
+    <mat-spinner style="margin:0 auto; top: 50%" mode="indeterminate" diameter="20"></mat-spinner>
+</div>
 <form [formGroup]="siteForm" (ngSubmit)="submitSiteForm()">
     <mat-dialog-content>
         <mat-accordion multi="true">
@@ -507,7 +510,7 @@
                                     <div *ngIf="siteFiles.FileEntity.filetype_id === 8">
                                         <mat-form-field appearance="fill">
                                             <mat-label>File URL</mat-label>
-                                            <input formControlName="name" matInput required [value]="siteFiles.FileEntity.name"/>
+                                            <input formControlName="name" matInput [value]="siteFiles.FileEntity.name"/>
                                             <mat-icon matSuffix class="info-icon" matTooltip="Please link to persistent URLs or digital object identifier (doi) urls." 
                                             aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>                
                                         </mat-form-field>
@@ -665,7 +668,7 @@
     </mat-dialog-content>
     <mat-dialog-actions align="end">
         <div class="detail-section-buttons centered">
-            <button mat-raised-button mat-dialog-close cdkFocusInitial aria-mat-label="Cancel">Cancel</button>
+            <button mat-raised-button [mat-dialog-close]="returnData" cdkFocusInitial aria-mat-label="Close">Close</button>
             <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
         </div>
     </mat-dialog-actions>

--- a/src/app/site-edit/site-edit.component.html
+++ b/src/app/site-edit/site-edit.component.html
@@ -356,7 +356,8 @@
                                             <table
                                                 mat-table
                                                 id="siteHousingTable"
-                                                [dataSource]="siteHousingArray"
+                                                [dataSource]="siteForm.controls.siteHousings.controls"
+                                                formArrayName="siteHousings"
                                                 class="mat-elevation-z5"
                                                 matSort
                                             >
@@ -364,19 +365,19 @@
                                                 <!-- housing type column -->
                                                 <ng-container matColumnDef="HousingType">
                                                     <th mat-header-cell *matHeaderCellDef>Housing Type</th>
-                                                    <td mat-cell *matCellDef="let housing">
-                                                        <div>
-                                                            {{housing.housingType}}
-                                                        </div>
+                                                    <td mat-cell *matCellDef="let housing; let i = index" [formGroupName]="i">
+                                                        <mat-form-field>
+                                                            <input matInput formControlName="housingType" [value]="housing.housingType" class="disabled"/>
+                                                        </mat-form-field>
                                                     </td>
                                                 </ng-container>
 
                                                 <!-- housing length column -->
                                                 <ng-container matColumnDef="HousingLength">
                                                     <th mat-header-cell *matHeaderCellDef>Housing Length (ft)</th>
-                                                    <td mat-cell *matCellDef="let housing">
+                                                    <td mat-cell *matCellDef="let housing; let i = index" [formGroupName]="i">
                                                         <mat-form-field appearance="fill">
-                                                            <input matInput [value]="housing.length" (change)="updateHousingAttr($event, housing)"/>
+                                                            <input matInput formControlName="length" [value]="housing.length"/>
                                                         </mat-form-field>
                                                     </td>
                                                 </ng-container>
@@ -384,9 +385,9 @@
                                                 <!-- housing material column -->
                                                 <ng-container matColumnDef="HousingMaterial">
                                                     <th mat-header-cell *matHeaderCellDef>Housing Material</th>
-                                                    <td mat-cell *matCellDef="let housing">
+                                                    <td mat-cell *matCellDef="let housing; let i = index" [formGroupName]="i">
                                                         <mat-form-field appearance="fill">
-                                                            <input matInput [value]="housing.material" (change)="updateHousingAttr($event, housing)"/>
+                                                            <input matInput formControlName="material" [value]="housing.material"/>
                                                         </mat-form-field>
                                                     </td>
                                                 </ng-container>
@@ -401,10 +402,10 @@
                                                     </th>
                                                     <td
                                                         mat-cell
-                                                        *matCellDef="let housing"
+                                                        *matCellDef="let housing; let i = index" [formGroupName]="i"
                                                     >
                                                         <mat-form-field appearance="fill">
-                                                            <input matInput [value]="housing.amount"/>
+                                                            <input formControlName="amount" matInput [value]="housing.amount"/>
                                                         </mat-form-field>
                                                     </td>
                                                 </ng-container>
@@ -412,9 +413,9 @@
                                                 <!-- housing notes column -->
                                                 <ng-container matColumnDef="Notes">
                                                     <th mat-header-cell *matHeaderCellDef>Notes</th>
-                                                    <td mat-cell *matCellDef="let housing">
+                                                    <td mat-cell *matCellDef="let housing; let i = index" [formGroupName]="i">
                                                         <mat-form-field appearance="fill">
-                                                            <input matInput [value]="housing.notes"/>
+                                                            <input formControlName="notes" matInput [value]="housing.notes"/>
                                                         </mat-form-field>
                                                     </td>
                                                 </ng-container>

--- a/src/app/site-edit/site-edit.component.html
+++ b/src/app/site-edit/site-edit.component.html
@@ -147,16 +147,16 @@
                         </div>
                         <mat-form-field appearance="fill">
                             <mat-label>Horizontal Datum</mat-label>
-                            <mat-select formControlName="hdatum" required [(value)]="site.hdatum">
-                                <mat-option *ngFor="let datum of hDatums" [value]="datum.datum_name">
+                            <mat-select formControlName="hdatum_id" required>
+                                <mat-option *ngFor="let datum of hDatums" [value]="datum.datum_id">
                                 {{datum.datum_name}}
                                 </mat-option>
                             </mat-select>
                         </mat-form-field>
                         <mat-form-field appearance="fill">
                             <mat-label>Horizontal Collection Method</mat-label>
-                            <mat-select formControlName="hmethod" required [(value)]="site.hmethod">
-                                <mat-option *ngFor="let method of hMethods" [value]="method.hcollect_method">
+                            <mat-select formControlName="hcollect_method_id" required [(value)]="site.hcollect_method_id">
+                                <mat-option *ngFor="let method of hMethods" [value]="method.hcollect_method_id">
                                 {{method.hcollect_method}}
                                 </mat-option>
                             </mat-select>
@@ -296,7 +296,7 @@
                                                 <mat-checkbox class="site-chx" [value]="useSiteAddress" (click)="useAddressforLO()" >Address same as Site address</mat-checkbox>
                                                 <mat-form-field appearance="fill">
                                                     <mat-label>Address</mat-label>
-                                                    <input formControlName="fname" matInput [value]="landownerContact.address"/>
+                                                    <input formControlName="address" matInput [value]="landownerContact.address"/>
                                                 </mat-form-field>
                                                 <mat-form-field appearance="fill">
                                                     <mat-label>City</mat-label>
@@ -445,7 +445,7 @@
                     </mat-panel-description>
                 </mat-expansion-panel-header>
                 <button mat-raised-button class="add-button" (click)="addSiteFile()" type="button"><mat-icon>add</mat-icon> Add File</button>
-                <div class="tableContainer" [hidden]="initSiteFiles.length === 0">
+                <div class="tableContainer" [hidden]="initSiteFiles?.length === 0">
                     <table
                         mat-table
                         id="siteFileTable"
@@ -469,7 +469,7 @@
                             <th mat-header-cell *matHeaderCellDef>File Date</th>
                             <td mat-cell *matCellDef="let file">
                                 <div>
-                                    {{file.file_date}}
+                                    {{file.format_file_date}}
                                 </div>
                             </td>
                         </ng-container>
@@ -495,7 +495,10 @@
                     
                                     <!--Upload Single Image with validations*-->
                                     <div *ngIf="addFileType === 'New' && siteFiles.filetype_id !== 8">
-                                        <input #upload class="upload-file" type="file" max="500000">
+                                        <label class="custom-file-input-add" for="addFile">
+                                            <p class="required">*</p>
+                                        </label>
+                                        <input #upload id="addFile" class="upload-file" type="file" max="500000" [hidden]="true" (click)="saveFileUpload($event)">
                                     </div>
                                     <br clear="all" />
 
@@ -529,7 +532,7 @@
                                     <div *ngIf="siteFiles.filetype_id === 1 || siteFiles.filetype_id > 2">
                                         <mat-form-field appearance="fill">
                                             <mat-label>Source Agency</mat-label>
-                                            <mat-select required formControlName="agency_id" (selectionChange)="updateAgencyForCaption($event)">
+                                            <mat-select required formControlName="agency_id" (selectionChange)="updateAgencyForCaption()">
                                                 <mat-option *ngFor="let a of agencies" [value]="a.agency_id">
                                                     {{a.agency_name}}
                                                 </mat-option>
@@ -625,13 +628,14 @@
                                             <span *ngIf="!fileItemExists">-- Missing --</span>
                                             <!--ReUpload Single Image with validations*-->
                                             <div *ngIf="!fileItemExists">
-                                                <!-- <label for="Upload"></label> -->
-                                                <input #upload id="Upload" type="file" max="500000" file-model="existingFile.File" (click)="saveFileUpload($event)">
+                                                <label class="custom-file-input" for="Upload"></label>
+                                                <input #upload [hidden]="true" id="Upload" type="file" max="500000" file-model="existingFile.File" (click)="saveFileUpload($event)">
                                             </div>
                                             <!-- change out the existing fileItem with a different one-->
                                             <div *ngIf="fileItemExists">
                                                 <div>
-                                                    <input #upload id="Upload" type="file" max="500000" file-model="existingFile.File1" (click)="saveFileUpload($event)">
+                                                    <label class="custom-file-inputChange" for="Upload"></label>
+                                                    <input #upload [hidden]="true" id="Upload" type="file" max="500000" file-model="existingFile.File1" (click)="saveFileUpload($event)">
                                                 </div>
                                             </div>
                                         </div>

--- a/src/app/site-edit/site-edit.component.scss
+++ b/src/app/site-edit/site-edit.component.scss
@@ -91,10 +91,20 @@ ul {
     color: #03274B;
 }
 
+.info-header-icon {
+    font-size: 20px;
+    color: #FFF;
+    text-align: right;
+}
+
 .tableContainer {
     width: 100%;
     margin-bottom: 20px;
     margin-top: 10px;
+}
+
+table {
+    width: 100%;
 }
 
 .mat-column-HousingType{
@@ -131,6 +141,19 @@ ul {
     align-self: stretch;
 }
 
+.mat-column-FileName{
+    padding: 10px;
+    vertical-align: middle;
+    border-right: 1px solid #e0e0e0;
+    align-self: stretch;
+}
+
+.mat-column-FileDate{
+    padding: 10px;
+    vertical-align: middle;
+    align-self: stretch;
+}
+
 .mat-header-cell {
     font-weight: bold;
     text-transform: uppercase;
@@ -145,6 +168,95 @@ ul {
     column-width: 150px;
 }
 
+#siteFileTable {
+    .mat-cell, .mat-header-cell, .mat-footer-cell {
+        overflow: auto;
+        column-width: 150px;
+    }
+}
+
+.file-table {
+    cursor: pointer;
+}
+
+.mat-expansion-panel-header-description {
+    flex-basis: 0;
+    justify-content: flex-end;
+    align-items: flex-start;
+}
+
 .add-button {
     margin: 10px;
+    background-color: #008248;
+    color: #F4F4F4;
+    border: 1px solid #2B7059;
+}
+
+.remove-button {
+    margin-bottom: 10px;
+    background-color: #E70000;
+    color: #F4F4F4;
+    border: 1px solid #ce0000;
+}
+
+.form-header {
+    font-weight: bold;
+}
+
+.event-alert {
+    margin: 10px;
+    border: solid 1px #ee992a;
+}
+
+.event-alert p{
+    display: inline;
+    vertical-align: middle;
+    color: #ee992a;
+    margin: 0px;
+}
+
+.warning-icon {
+    padding-right: 10px;
+    color: #ee992a;
+    display: inline;
+    vertical-align: middle;
+}
+
+.alert.alert-danger {
+    color: #f44336;
+}
+
+.site-button-group {
+    margin-top: 10px;
+    text-align: center;
+}
+
+.save-btn {
+    background-color: #008248;
+    color: #F4F4F4;
+    border: 1px solid #2B7059;
+}
+
+.cancel-btn {
+    margin-left: 10px;
+}
+
+.delete-btn {
+    background-color: #E70000;
+    color: #F4F4F4;
+    border: 1px solid #ce0000;
+    margin-left: 10px;
+}
+
+.file-button-group {
+    margin-top: 10px;
+    text-align: center;
+}
+
+.upload-file {
+    margin-left: 20px;
+}
+
+.invalid {
+    padding: 15px;
 }

--- a/src/app/site-edit/site-edit.component.scss
+++ b/src/app/site-edit/site-edit.component.scss
@@ -1,0 +1,150 @@
+.mat-expansion-panel-header {
+    background-color: #03274B;
+}
+
+.mat-expansion-panel .mat-expansion-panel-header.mat-expanded {
+    color: #FFF;
+    background-color: #03274B; 
+}
+
+.mat-expansion-panel-header:hover {
+    background-color: #03274B !important;
+    color: #FFF !important;
+}
+
+.mat-expansion-panel .mat-expansion-panel-header .mat-expansion-panel-header-title {
+    color: #FFF;
+    font-weight: 500;
+}
+.table-container {
+    display: inline-block;
+    margin: auto;
+    width: 50%;
+    vertical-align: top;
+}
+
+.outer-content{
+    display: table;
+    margin: auto;
+}
+
+.content-right {
+    display: table-cell;
+    width: 50%;
+    text-align: left;
+}
+
+.content-left {
+    display: table-cell;
+    width: 50%;
+    padding-right: 5px;
+    text-align: right;
+    font-weight: bold;
+}
+
+.cell-container {
+    display: table-row;
+}
+
+.cell-container label{
+    padding: 5px;
+    font-size: 15px
+}
+
+.cell-container input{
+    padding: 5px;
+    font-size: 15px
+}
+
+.mat-form-field {
+    display: block;
+}
+
+ul {
+    list-style-type: none;
+}
+
+#sensorAppropriate {
+    margin-bottom: 15px;
+}
+
+#latLngUnit {
+    margin: 15px;
+}
+
+.radio-group {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 15px;
+}
+
+.radio-button {
+    margin: 5px;
+}
+
+.mat-form-field {
+    margin: 15px;
+}
+
+.info-icon {
+    font-size: 20px;
+    color: #03274B;
+}
+
+.tableContainer {
+    width: 100%;
+    margin-bottom: 20px;
+    margin-top: 10px;
+}
+
+.mat-column-HousingType{
+    padding: 10px;
+    border-right: 1px solid #e0e0e0;
+    vertical-align: middle;
+    align-self: stretch;
+}
+
+.mat-column-HousingLength{
+    padding: 10px;
+    border-right: 1px solid #e0e0e0;
+    vertical-align: middle;
+    align-self: stretch;
+} 
+
+.mat-column-HousingMaterial{
+    padding: 10px;
+    border-right: 1px solid #e0e0e0;
+    vertical-align: middle;
+    align-self: stretch;
+}
+
+.mat-column-Amount{
+    padding: 10px;
+    vertical-align: middle;
+    border-right: 1px solid #e0e0e0;
+    align-self: stretch;
+}
+
+.mat-column-Notes{
+    padding: 10px;
+    vertical-align: middle;
+    align-self: stretch;
+}
+
+.mat-header-cell {
+    font-weight: bold;
+    text-transform: uppercase;
+    color:rgba(0, 0, 0, 0.87);
+    font-size: 12px;
+    vertical-align: middle;
+    background-color: #f7f7f7;
+}
+
+.mat-cell, .mat-header-cell, .mat-footer-cell {
+    overflow: auto;
+    column-width: 150px;
+}
+
+.add-button {
+    margin: 10px;
+}

--- a/src/app/site-edit/site-edit.component.scss
+++ b/src/app/site-edit/site-edit.component.scss
@@ -333,3 +333,17 @@ table {
 .file-upload-span {
     padding-top: 10px;
 }
+
+.loading {
+    position:absolute;
+    left:0;
+    top:0;
+    width:100%;
+    height:100%;
+    background:rgba(255,255,255,0.8);
+    z-index:9999;
+}
+
+.close-button {
+    float: right;
+}

--- a/src/app/site-edit/site-edit.component.scss
+++ b/src/app/site-edit/site-edit.component.scss
@@ -325,3 +325,7 @@ table {
     line-height: 36px !important;
     height: 36px;
 }
+
+.file-upload-span {
+    padding-top: 10px;
+}

--- a/src/app/site-edit/site-edit.component.scss
+++ b/src/app/site-edit/site-edit.component.scss
@@ -48,12 +48,12 @@
 
 .cell-container label{
     padding: 5px;
-    font-size: 15px
+    font-size: 15px;
 }
 
 .cell-container input{
     padding: 5px;
-    font-size: 15px
+    font-size: 15px;
 }
 
 .mat-form-field {
@@ -165,7 +165,11 @@ table {
 
 .mat-cell, .mat-header-cell, .mat-footer-cell {
     overflow: auto;
-    column-width: 150px;
+    column-width: 170px;
+}
+
+.disabled {
+    color: #000;
 }
 
 #siteFileTable {

--- a/src/app/site-edit/site-edit.component.scss
+++ b/src/app/site-edit/site-edit.component.scss
@@ -260,3 +260,68 @@ table {
 .invalid {
     padding: 15px;
 }
+
+.custom-file-input::-webkit-file-upload-button, .custom-file-inputChange::-webkit-file-upload-button, .custom-file-input-add::-webkit-file-upload-button {
+    visibility: hidden;
+}
+
+.custom-file-input-add::before {
+    content: 'Choose File';
+    display: inline-block;
+    background: #FFF;
+    border: none;
+    border-radius: 4px;
+    padding: 0px 16px;
+    outline: none;
+    white-space: nowrap;
+    -webkit-user-select: none;
+    user-select: none;
+    cursor: pointer;
+    box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.20), 0px 2px 2px 0px rgba(0, 0, 0, .14), 0px 1px 5px 0px rgba(0, 0, 0, .12);
+    line-height: 36px;
+    margin-top: 10px;
+}
+
+.custom-file-input::before {
+    content: 'Re-Upload File';
+    display: inline-block;
+    background: #FFF;
+    border: none;
+    border-radius: 4px;
+    padding: 0px 16px;
+    outline: none;
+    white-space: nowrap;
+    -webkit-user-select: none;
+    user-select: none;
+    cursor: pointer;
+    box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.20), 0px 2px 2px 0px rgba(0, 0, 0, .14), 0px 1px 5px 0px rgba(0, 0, 0, .12);
+    line-height: 36px;
+    margin-top: 10px;
+}
+
+.custom-file-inputChange::before {
+    content: 'Replace Associated File';
+    display: inline-block;
+    background: #FFF;
+    border: none;
+    border-radius: 4px;
+    padding: 0px 16px;
+    outline: none;
+    white-space: nowrap;
+    -webkit-user-select: none;
+    user-select: none;
+    cursor: pointer;
+    box-shadow: 0px 3px 1px -2px rgba(0, 0, 0, 0.20), 0px 2px 2px 0px rgba(0, 0, 0, .14), 0px 1px 5px 0px rgba(0, 0, 0, .12);
+    line-height: 36px;
+    margin-top: 10px;
+}
+
+.required {
+    margin-left: 5px !important;
+    color: #E70000 !important;
+    font-weight: bold;
+    display: inline-block;
+    vertical-align: top;
+    line-height: 36px !important;
+    height: 36px;
+}

--- a/src/app/site-edit/site-edit.component.spec.ts
+++ b/src/app/site-edit/site-edit.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SiteEditComponent } from './site-edit.component';
+
+describe('SiteEditComponent', () => {
+  let component: SiteEditComponent;
+  let fixture: ComponentFixture<SiteEditComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SiteEditComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SiteEditComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/site-edit/site-edit.component.spec.ts
+++ b/src/app/site-edit/site-edit.component.spec.ts
@@ -1,14 +1,16 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, tick } from '@angular/core/testing';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatDialogModule } from '@angular/material/dialog';
 import { SiteService } from '@app/services/site.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { MatTableModule } from '@angular/material/table';
+import {MatSnackBarModule} from '@angular/material/snack-bar';
 
 import { SiteEditComponent } from './site-edit.component';
 import { of } from 'rxjs';
 import { APP_SETTINGS } from '@app/app.settings';
+import { FormArray, FormControl, FormGroup } from '@angular/forms';
 
 describe('SiteEditComponent', () => {
   let component: SiteEditComponent;
@@ -65,6 +67,7 @@ describe('SiteEditComponent', () => {
         MatDialogModule,
         HttpClientTestingModule,
         MatTableModule,
+        MatSnackBarModule,
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     })
@@ -105,7 +108,7 @@ describe('SiteEditComponent', () => {
     fixture.detectChanges();
     expect(component.networkTypes).toEqual([{network_type_name: "test", selected: true}]);
     expect(component.selectedNetworkTypes.length).toEqual(1);
-    expect(component.siteForm.controls.networkType.length).toEqual(1);
+    expect(component.siteForm.get('networkType').length).toEqual(1);
 
     data.networkType = null;
   });
@@ -134,7 +137,7 @@ describe('SiteEditComponent', () => {
     fixture.detectChanges();
     expect(component.networkNames).toEqual([{name: "test", selected: true}]);
     expect(component.selectedNetworkNames.length).toEqual(1);
-    expect(component.siteForm.controls.networkName.length).toEqual(1);
+    expect(component.siteForm.get('networkName').length).toEqual(1);
 
     data.networkName = null;
   });
@@ -149,9 +152,9 @@ describe('SiteEditComponent', () => {
 
     component.getNetworkNames();
     fixture.detectChanges();
-    expect(component.isDisabled).toBeTrue;
+    expect(component.isDisabled).toBeTrue();
     expect(component.selectedNetworkNames.length).toEqual(1);
-    expect(component.siteForm.controls.networkName.length).toEqual(1);
+    expect(component.siteForm.get('networkName').length).toEqual(1);
     expect(component.networkNames).toEqual([{name: "Not Defined", selected: true}, {name: "test", selected: false}])
 
     data.networkName = null;
@@ -188,7 +191,7 @@ describe('SiteEditComponent', () => {
     component.setSelectedNetworkName(event, data);
     fixture.detectChanges();
     expect(data.selected).toEqual(true);
-    expect(component.isDisabled).toBeTrue;
+    expect(component.isDisabled).toBeTrue();
     expect(component.selectedNetworkNames.length).toEqual(1);
     expect(component.networkNames[0].selected).toEqual(true);
     expect(component.networkNames[1].selected).toEqual(false);
@@ -202,7 +205,7 @@ describe('SiteEditComponent', () => {
     fixture.detectChanges();
     expect(data.selected).toEqual(false);
     expect(component.selectedNetworkNames.length).toEqual(0);
-    expect(component.isDisabled).toBeFalse;
+    expect(component.isDisabled).toBeFalse();
   });
 
   xit('should add or remove rows in the housing type table', () => {
@@ -278,18 +281,18 @@ describe('SiteEditComponent', () => {
     component.getStateList();
     fixture.detectChanges();
     expect(component.stateList).toEqual(response);
-    expect(component.siteForm.controls['state'].value).toEqual("Alabama");
+    expect(component.siteForm.get('state').value).toEqual("AL");
   });
 
   it('should set the county lookup', () => {
     const response: any[] = ["county1", "county2"];
-    component.stateList = [{state_name: "Alabama", state_id: 1}, {state_name: "Idaho", state_id: 2}];
+    component.stateList = [{state_name: "Alabama", state_id: 1, state_abbrev: "AL"}, {state_name: "Idaho", state_id: 2, state_abbrev: "ID"}];
     
     spyOn(component.siteService, 'getAllCounties').and.returnValue(
         of(response)
     );
 
-    component.getCountyList("Alabama");
+    component.getCountyList("AL");
     fixture.detectChanges();
     expect(component.countyList).toEqual(response);
   });
@@ -297,7 +300,7 @@ describe('SiteEditComponent', () => {
   it('should add landowner contact', () => {
     component.addLandownerContact();
     fixture.detectChanges();
-    expect(component.addLandownerCheck).toBeTrue;
+    expect(component.addLandownerCheck).toBeTrue();
   });
 
   it('should set LO address to site address', () => {
@@ -309,16 +312,16 @@ describe('SiteEditComponent', () => {
 
     component.useAddressforLO();
     fixture.detectChanges();
-    expect(component.landownerForm.dirty).toBeTrue;
-    expect(component.useSiteAddress).toBeTrue;
+    expect(component.landownerForm.dirty).toBeTrue();
+    expect(component.useSiteAddress).toBeTrue();
     expect(component.landownerContact.address).toEqual("000 Test Street");
     expect(component.landownerContact.city).toEqual("Test City");
     expect(component.landownerContact.state).toEqual("Alabama");
     expect(component.landownerContact.zip).toEqual("00000");
-    expect(component.landownerForm.controls['address'].value).toEqual("000 Test Street");
-    expect(component.landownerForm.controls['city'].value).toEqual("Test City");
-    expect(component.landownerForm.controls['state'].value).toEqual("Alabama");
-    expect(component.landownerForm.controls['zip'].value).toEqual("00000");
+    expect(component.landownerForm.get('address').value).toEqual("000 Test Street");
+    expect(component.landownerForm.get('city').value).toEqual("Test City");
+    expect(component.landownerForm.get('state').value).toEqual("Alabama");
+    expect(component.landownerForm.get('zip').value).toEqual("00000");
   });
 
   it('should remove site address from LO address', () => {
@@ -330,16 +333,16 @@ describe('SiteEditComponent', () => {
 
     component.useAddressforLO();
     fixture.detectChanges();
-    expect(component.landownerForm.dirty).toBeTrue;
-    expect(component.useSiteAddress).toBeFalse;
+    expect(component.landownerForm.dirty).toBeTrue();
+    expect(component.useSiteAddress).toBeFalse();
     expect(component.landownerContact.address).toEqual("");
     expect(component.landownerContact.city).toEqual("");
     expect(component.landownerContact.state).toEqual("");
     expect(component.landownerContact.zip).toEqual("");
-    expect(component.landownerForm.controls['address'].value).toEqual("");
-    expect(component.landownerForm.controls['city'].value).toEqual("");
-    expect(component.landownerForm.controls['state'].value).toEqual("");
-    expect(component.landownerForm.controls['zip'].value).toEqual("");
+    expect(component.landownerForm.get('address').value).toEqual("");
+    expect(component.landownerForm.get('city').value).toEqual("");
+    expect(component.landownerForm.get('state').value).toEqual("");
+    expect(component.landownerForm.get('zip').value).toEqual("");
   });
 
   it('should format date', () => {
@@ -383,8 +386,8 @@ describe('SiteEditComponent', () => {
   });
 
   it('should set the agency name for the preview caption', () => {
-    component.siteFileForm.controls["filetype_id"].value = 1;
-    component.siteFileForm.controls["agency_id"].value = 0;
+    component.siteFileForm.get("filetype_id").value = 1;
+    component.siteFileForm.get("agency_id").value = 0;
     component.agencies = [{agency_name: "WIM", agency_id: 0}];
     component.updateAgencyForCaption();
     fixture.detectChanges();
@@ -396,14 +399,14 @@ describe('SiteEditComponent', () => {
     component.sensorAppropriateChanged(event);
     fixture.detectChanges();
     expect(component.perm_housing_installed).toEqual("No");
-    expect(component.siteForm.controls['is_permanent_housing_installed'].value).toEqual("No");
-    expect(component.siteForm.controls['is_permanent_housing_installed'].disabled).toEqual(true);
+    expect(component.siteForm.get('is_permanent_housing_installed').value).toEqual("No");
+    expect(component.siteForm.get('is_permanent_housing_installed').disabled).toEqual(true);
 
     // should enable permanent housing when unchecked
     event = {checked: false};
     component.sensorAppropriateChanged(event);
     fixture.detectChanges();
-    expect(component.siteForm.controls['is_permanent_housing_installed'].disabled).toEqual(false);
+    expect(component.siteForm.get('is_permanent_housing_installed').disabled).toEqual(false);
   });
 
   it('should reset and show file edit form', () => {
@@ -418,14 +421,14 @@ describe('SiteEditComponent', () => {
     expect(setInitFile).toHaveBeenCalled;
     expect(component.addFileType).toEqual("Existing");
     expect(getFileSpy).toHaveBeenCalled;
-    expect(component.siteFiles.source_id).toEqual(1);
-    expect(component.siteFiles.file_id).toEqual(1);
-    expect(component.siteFiles.filetype_id).toEqual(1);
-    expect(component.siteFiles.file_date).toEqual(row.file_date);
-    expect(component.siteFiles.photo_date).toEqual(row.photo_date);
-    expect(component.siteFiles.photo_direction).toEqual(null);
-    expect(component.siteFiles.latitude_dd).toEqual(45.86);
-    expect(component.siteFiles.longitude_dd).toEqual(-87.60);
+    expect(component.siteFiles.FileEntity.source_id).toEqual(1);
+    expect(component.siteFiles.FileEntity.file_id).toEqual(1);
+    expect(component.siteFiles.FileEntity.filetype_id).toEqual(1);
+    expect(component.siteFiles.FileEntity.file_date).toEqual(row.file_date);
+    expect(component.siteFiles.FileEntity.photo_date).toEqual(row.photo_date);
+    expect(component.siteFiles.FileEntity.photo_direction).toEqual(null);
+    expect(component.siteFiles.FileEntity.latitude_dd).toEqual(45.86);
+    expect(component.siteFiles.FileEntity.longitude_dd).toEqual(-87.60);
   });
 
   it('set initial file edit form control values', () => {
@@ -433,18 +436,18 @@ describe('SiteEditComponent', () => {
 
     component.setInitFileEditForm(data);
     fixture.detectChanges();
-    expect(component.siteFileForm.controls.source_id.value).toEqual(1);
-    expect(component.siteFileForm.controls.file_id.value).toEqual(1);
-    expect(component.siteFileForm.controls.filetype_id.value).toEqual(1);
-    expect(component.siteFileForm.controls.file_date.value).toEqual(data.file_date);
-    expect(component.siteFileForm.controls.photo_date.value).toEqual(data.photo_date);
-    expect(component.siteFileForm.controls.photo_direction.value).toEqual("");
-    expect(component.siteFileForm.controls.latitude_dd.value).toEqual(45.86);
-    expect(component.siteFileForm.controls.longitude_dd.value).toEqual(-87.60);
+    expect(component.siteFileForm.get('source_id').value).toEqual(1);
+    expect(component.siteFileForm.get('file_id').value).toEqual(1);
+    expect(component.siteFileForm.get('filetype_id').value).toEqual(1);
+    expect(component.siteFileForm.get('file_date').value).toEqual(data.file_date);
+    expect(component.siteFileForm.get('photo_date').value).toEqual(data.photo_date);
+    expect(component.siteFileForm.get('photo_direction').value).toEqual("");
+    expect(component.siteFileForm.get('latitude_dd').value).toEqual(45.86);
+    expect(component.siteFileForm.get('longitude_dd').value).toEqual(-87.60);
   });
 
   it('should get the file item name', () => {
-    component.siteFiles.file_id = 1;
+    component.siteFiles.FileEntity.file_id = 1;
     const response = {FileName: "testFile"};
     
     spyOn(component.siteService, 'getFileItem').and.returnValue(
@@ -458,14 +461,14 @@ describe('SiteEditComponent', () => {
     fixture.detectChanges();
     expect(component.fileItemExists).toEqual(true);
     expect(component.fileSource).toEqual(APP_SETTINGS.API_ROOT + 'Files/1/item')
-    expect(component.siteFiles.name).toEqual("testFile");
-    expect(component.siteFileForm.controls.name.value).toEqual("testFile");
+    expect(component.siteFiles.FileEntity.name).toEqual("testFile");
+    expect(component.siteFileForm.get('name').value).toEqual("testFile");
     expect(fileAgencySpy).toHaveBeenCalled;
     expect(fileSourceSpy).toHaveBeenCalled;
   });
 
   it('should set the file source agency', () => {
-    component.siteFiles.source_id = 1;
+    component.siteFiles.FileEntity.source_id = 1;
     const response = {agency_name: "WIM", agency_id: 0};
     
     spyOn(component.siteService, 'getFileSource').and.returnValue(
@@ -475,12 +478,12 @@ describe('SiteEditComponent', () => {
     component.setFileSourceAgency();
     fixture.detectChanges();
     expect(component.agencyNameForCap).toEqual("WIM");
-    expect(component.siteFiles.agency_id).toEqual(0);
-    expect(component.siteFileForm.controls.agency_id.value).toEqual(0);
+    expect(component.siteFiles.FileEntity.agency_id).toEqual(0);
+    expect(component.siteFileForm.get('agency_id').value).toEqual(0);
   });
 
   it('should set the file source', () => {
-    component.siteFiles.source_id = 1;
+    component.siteFiles.FileEntity.source_id = 1;
     const response = {source_name: "John Smith"};
     
     spyOn(component.siteService, 'getSourceName').and.returnValue(
@@ -489,8 +492,541 @@ describe('SiteEditComponent', () => {
 
     component.setFileSource();
     fixture.detectChanges();
-    expect(component.siteFiles.FULLname).toEqual("John Smith");
-    expect(component.siteFileForm.controls.FULLname.value).toEqual("John Smith");
+    expect(component.siteFiles.FileEntity.FULLname).toEqual("John Smith");
+    expect(component.siteFileForm.get('FULLname').value).toEqual("John Smith");
   });
 
+  it('should change lat/lng unit', () => {
+    let event = {value: "decdeg"};
+    component.siteForm.get("latdeg").setValue(47);
+    component.siteForm.get("latmin").setValue(26);
+    component.siteForm.get("latsec").setValue(30.012);
+    component.siteForm.get("londeg").setValue(-91);
+    component.siteForm.get("lonmin").setValue(44);
+    component.siteForm.get("lonsec").setValue(30.012);
+
+    component.changeLatLngUnit(event);
+    fixture.detectChanges();
+    expect(component.siteForm.get('latitude_dd').value).toEqual('47.44167');
+    expect(component.siteForm.get('longitude_dd').value).toEqual('-91.74167');
+    expect(component.incorrectDMS).toBeFalse();
+
+    event = {value: "decdeg"};
+    component.siteForm.get("latdeg").setValue(undefined);
+    component.siteForm.get("latmin").setValue(26);
+    component.siteForm.get("latsec").setValue(30.012);
+    component.siteForm.get("londeg").setValue(undefined);
+    component.siteForm.get("lonmin").setValue(44);
+    component.siteForm.get("lonsec").setValue(30.012);
+    // clear lat/lng values before function is executed again
+    component.siteForm.get("latitude_dd").setValue(null);
+    component.siteForm.get("longitude_dd").setValue(null);
+
+    component.changeLatLngUnit(event);
+    fixture.detectChanges();
+    expect(component.siteForm.get('latitude_dd').value).toEqual(null);
+    expect(component.siteForm.get('longitude_dd').value).toEqual(null);
+    expect(component.incorrectDMS).toBeTrue();
+
+    event = {value: "dms"}
+    component.siteForm.get("latitude_dd").setValue(47.44167);
+    component.siteForm.get("longitude_dd").setValue(-91.74167);
+
+    component.changeLatLngUnit(event);
+    fixture.detectChanges();
+    expect(component.siteForm.get('latdeg').value).toEqual('47');
+    expect(component.siteForm.get('latmin').value).toEqual('26');
+    expect(component.siteForm.get('latsec').value).toEqual('30.012');
+    expect(component.siteForm.get('londeg').value).toEqual('-91');
+    expect(component.siteForm.get('lonmin').value).toEqual('44');
+    expect(component.siteForm.get('lonsec').value).toEqual('30.012');
+  });
+
+  it('should re-upload file', () => {
+    const response = {
+      description: "test 24224",
+      fileBelongsTo: "Site File",
+      fileType: "Link",
+      file_date: "2021-12-06T18:00:00",
+      file_id: 108937,
+      filetype_id: 8,
+      latitude_dd: null,
+      longitude_dd: null,
+      name: "test file 24224",
+      photo_date: "2021-12-06T18:00:00",
+      photo_direction: null,
+      site_id: 24224,
+      source_id: 3313,
+    }
+
+    component.returnData.files = [{file_id: 108937}];
+    
+    spyOn(component.siteEditService, 'uploadFile').and.returnValue(
+        of(response)
+    );
+
+    component.saveFileUpload();
+    fixture.detectChanges();
+    expect(component.returnData.files).toEqual([response]);
+    expect(component.initSiteFiles).toEqual([response]);
+  });
+
+  it('should set file attributes', () => {
+    let event = {target: {files: [{name: "testFile"}]}};
+
+    component.returnData.files = [{file_id: 108937}];
+
+    component.getFileName(event);
+    fixture.detectChanges();
+    expect(component.fileUploading).toEqual(true);
+    expect(component.siteFiles.File).toEqual({name: "testFile"});
+    expect(component.siteFileForm.get("photo_date").validator).toEqual(null);
+  });
+
+  it('should hide and reset file form', () => {
+    component.cancelFile();
+    fixture.detectChanges();
+    expect(component.showFileForm).toBeFalse();
+    expect(component.siteFiles).toEqual({
+      FileEntity: {
+        file_id: null,
+        name: null,
+        FULLname: null,
+        source_id: null,
+        description: null,
+        file_date: null,
+        photo_date: null,
+        agency_id: null,
+        site_id: null,
+        filetype_id: null,
+        path: null,
+        last_updated: null,
+        last_updated_by: null,
+        site_description: null,
+        photo_direction: null,
+        latitude_dd: null,
+        longitude_dd: null,
+      },
+      File: null
+    });
+  });
+
+  it('should show blank file form and set default date value', () => {
+    component.addSiteFile();
+    fixture.detectChanges();
+    expect(component.showFileForm).toBeTrue();
+    expect(component.addFileType).toEqual("New");
+    expect(component.siteFileForm.get("file_date").value).not.toEqual(null);
+    expect(component.siteFileForm.get("photo_date").value).not.toEqual(null);
+  });
+
+  it('should show alert and stop loading if site form is invalid', () => {
+    component.siteForm.get("site_description").setValue(null);
+    spyOn(window, 'alert');
+
+    component.submitSiteForm();
+    fixture.detectChanges();
+    expect(component.valid).toBeFalse();
+    expect(component.loading).toBeFalse();
+    expect(window.alert).toHaveBeenCalledWith("Some required site fields are missing or incorrect.  Please fix these fields before submitting.");
+  });
+
+  it('should call put site if no landowner', () => {
+    component.siteForm.get("site_description").setValue("test");
+    component.siteForm.get("county").setValue("Dane");
+    component.siteForm.get("hcollect_method_id").setValue(2);
+    component.siteForm.get("hdatum_id").setValue(2);
+    component.siteForm.get("state").setValue("WI");
+    component.siteForm.get("waterbody").setValue("test");
+
+    let putSiteSpy = spyOn(component, 'putSite');
+
+    component.submitSiteForm();
+    fixture.detectChanges();
+    expect(component.valid).toBeTrue();
+    expect(component.loading).toBeTrue();
+    expect(putSiteSpy).toHaveBeenCalled();
+  });
+
+  it('should call putSite and show alert if landowner invalid', () => {
+    component.siteForm.get("site_description").setValue("test");
+    component.siteForm.get("county").setValue("Dane");
+    component.siteForm.get("hcollect_method_id").setValue(2);
+    component.siteForm.get("hdatum_id").setValue(2);
+    component.siteForm.get("state").setValue("WI");
+    component.siteForm.get("waterbody").setValue("test");
+
+    component.siteForm.get("landownercontact_id").setValue(9999);
+    component.landownerForm.markAsDirty();
+    let putSiteSpy = spyOn(component, 'putSite');
+    spyOn(window, 'alert');
+
+    component.submitSiteForm();
+    fixture.detectChanges();
+
+    expect(component.landownerValid).toBeFalse();
+    expect(putSiteSpy).toHaveBeenCalled();
+    expect(window.alert).toHaveBeenCalledWith("Error creating landowner contact.");
+  });
+
+  it('should call putSite and post landowner form', () => {
+    let response = {};
+    component.siteForm.get("site_description").setValue("test");
+    component.siteForm.get("county").setValue("Dane");
+    component.siteForm.get("hcollect_method_id").setValue(2);
+    component.siteForm.get("hdatum_id").setValue(2);
+    component.siteForm.get("state").setValue("WI");
+    component.siteForm.get("waterbody").setValue("test");
+
+    component.landownerForm.get("landownercontact_id").setValue(null);
+    component.landownerForm.get("fname").setValue("test");
+    component.landownerForm.markAsDirty();
+    let putSiteSpy = spyOn(component, 'putSite');
+    let postLandownerSpy = spyOn(component.siteEditService, 'postLandowner').and.returnValue(
+      of(response)
+    );
+
+    component.submitSiteForm();
+    fixture.detectChanges();
+
+    expect(component.landownerValid).toBeTrue();
+    expect(putSiteSpy).toHaveBeenCalled();
+    expect(postLandownerSpy).toHaveBeenCalledWith(component.landownerForm.value);
+  });
+
+  it('should call putSite and put landowner form', () => {
+    let response = {};
+    component.siteForm.get("site_description").setValue("test");
+    component.siteForm.get("county").setValue("Dane");
+    component.siteForm.get("hcollect_method_id").setValue(2);
+    component.siteForm.get("hdatum_id").setValue(2);
+    component.siteForm.get("state").setValue("WI");
+    component.siteForm.get("waterbody").setValue("test");
+
+    component.landownerForm.get("fname").setValue("test");
+    component.landownerForm.get("landownercontact_id").setValue(9999);
+    component.landownerForm.markAsDirty();
+    let putSiteSpy = spyOn(component, 'putSite');
+    let putLandownerSpy = spyOn(component.siteEditService, 'putLandowner').and.returnValue(
+      of(response)
+    );
+
+    component.submitSiteForm();
+    fixture.detectChanges();
+
+    expect(component.landownerValid).toBeTrue();
+    expect(putSiteSpy).toHaveBeenCalled();
+    expect(putLandownerSpy).toHaveBeenCalledWith(component.landownerForm.get("landownercontact_id").value, component.landownerForm.value);
+  });
+
+  it('should delete file and remove from page', () => {
+    component.returnData.files = [{file_id: 1}, {file_id: 2}];
+    let response = {file_id: 1};
+    spyOn(window, 'confirm').and.returnValue(true);
+    spyOn(component.siteEditService, 'deleteFile').and.returnValue(
+      of(response)
+    );
+
+    component.deleteFile();
+    fixture.detectChanges();
+    
+    expect(component.returnData.files.length).toEqual(1);
+    expect(component.returnData.files).toEqual([{file_id: 2}]);
+    expect(component.initSiteFiles).toEqual([{file_id: 2}]);
+    expect(component.showFileForm).toBeFalse();
+  });
+
+  it('should create file and add to page', () => {
+    component.siteFileForm.get("filetype_id").setValue(1);
+    component.siteFileForm.get("file_date").setValue("2018-12-29T22:55:17.129");
+    component.siteFileForm.get("site_id").setValue(24224);
+    component.siteFileForm.get("description").setValue("test file");
+    component.siteFileForm.get("FULLname").setValue("test");
+    component.siteFileForm.get("agency_id").setValue(9999);
+    component.returnData.files = [];
+
+    let response = {filetype_id: 1, file_date: "2018-12-29T22:55:17.129", site_id: 242224, description: "test file"};
+    let sourceResponse = { source_name: "test", source_id: 9999}
+    spyOn(component.siteEditService, 'postSource').and.returnValue(
+      of(sourceResponse)
+    );
+    spyOn(component.siteEditService, 'uploadFile').and.returnValue(
+      of(response)
+    );
+
+    component.createFile();
+    fixture.detectChanges();
+
+    expect(component.returnData.files).toEqual([ {filetype_id: 1, file_date: "2018-12-29T22:55:17.129", site_id: 242224, description: "test file", format_file_date: '12/29/2018'} ]);
+    expect(component.initSiteFiles).toEqual([ {filetype_id: 1, file_date: "2018-12-29T22:55:17.129", site_id: 242224, description: "test file", format_file_date: '12/29/2018'} ]);
+    expect(component.loading).toBeFalse();
+    expect(component.showFileForm).toBeFalse();
+  });
+
+  it('should create link file and add to page', () => {
+    component.siteFileForm.get("filetype_id").setValue(8);
+    component.siteFileForm.get("file_date").setValue("2018-12-29T22:55:17.129");
+    component.siteFileForm.get("description").setValue("test file");
+    component.siteFileForm.get("FULLname").setValue("test");
+    component.siteFileForm.get("agency_id").setValue(9999);
+    component.returnData.files = [];
+    component.data.site.site_id = 24224;
+
+    let response = {filetype_id: 8, file_date: "2018-12-29T22:55:17.129", site_id: 242224, description: "test file"};
+    let sourceResponse = { source_name: "test", source_id: 9999}
+    spyOn(component.siteEditService, 'postSource').and.returnValue(
+      of(sourceResponse)
+    );
+    spyOn(component.siteEditService, 'saveFile').and.returnValue(
+      of(response)
+    );
+
+    component.createFile();
+    fixture.detectChanges();
+
+    expect(component.returnData.files).toEqual([ {filetype_id: 8, file_date: "2018-12-29T22:55:17.129", site_id: 242224, description: "test file", format_file_date: '12/29/2018'} ]);
+    expect(component.initSiteFiles).toEqual([ {filetype_id: 8, file_date: "2018-12-29T22:55:17.129", site_id: 242224, description: "test file", format_file_date: '12/29/2018'} ]);
+    expect(component.loading).toBeFalse();
+    expect(component.showFileForm).toBeFalse();
+  });
+
+  it('should cancel loading and show alert if file form is invalid', () => {
+    component.siteFileForm.get("filetype_id").setValue(8);
+    component.siteFileForm.get("file_date").setValue("2018-12-29T22:55:17.129");
+    component.siteFileForm.get("FULLname").setValue("test");
+    component.siteFileForm.get("agency_id").setValue(9999);
+    spyOn(window, 'alert');
+
+    component.createFile();
+    fixture.detectChanges();
+
+    expect(window.alert).toHaveBeenCalledWith("Some required site file fields are missing or incorrect.  Please fix these fields before submitting.");
+    expect(component.loading).toBeFalse();
+  });
+
+  it('should update exisiting file', () => {
+    component.siteFileForm.get("filetype_id").setValue(8);
+    component.siteFileForm.get("file_date").setValue("2018-12-29T22:55:17.129");
+    component.siteFileForm.get("description").setValue("test file");
+    component.siteFileForm.get("FULLname").setValue("test");
+    component.siteFileForm.get("agency_id").setValue(9999);
+    component.siteFileForm.get("source_id").setValue(9999);
+    component.returnData.files = [{filetype_id: 8, file_date: "2018-12-29T22:55:17.129", site_id: 242224, description: "test", file_id: 9999}];
+    component.data.site.site_id = 24224;
+
+    let response = {filetype_id: 8, file_date: "2018-12-29T22:55:17.129", site_id: 242224, description: "test file", file_id: 9999};
+    let sourceResponse = { source_name: "test", source_id: 9999}
+    spyOn(component.siteEditService, 'postSource').and.returnValue(
+      of(sourceResponse)
+    );
+    spyOn(component.siteEditService, 'updateFile').and.returnValue(
+      of(response)
+    );
+
+    component.saveFile();
+    fixture.detectChanges();
+
+    expect(component.returnData.files).toEqual([ {filetype_id: 8, file_date: "2018-12-29T22:55:17.129", site_id: 242224, description: "test file", file_id: 9999, format_file_date: '12/29/2018'} ]);
+    expect(component.initSiteFiles).toEqual([ {filetype_id: 8, file_date: "2018-12-29T22:55:17.129", site_id: 242224, description: "test file", file_id: 9999, format_file_date: '12/29/2018'} ]);
+    expect(component.loading).toBeFalse();
+    expect(component.showFileForm).toBeFalse();
+  });
+
+  it('should cancel loading and show alert if file update form is invalid', () => {
+    component.siteFileForm.get("filetype_id").setValue(8);
+    component.siteFileForm.get("file_date").setValue("2018-12-29T22:55:17.129");
+    component.siteFileForm.get("FULLname").setValue("test");
+    component.siteFileForm.get("agency_id").setValue(9999);
+    spyOn(window, 'alert');
+
+    component.saveFile();
+    fixture.detectChanges();
+
+    expect(window.alert).toHaveBeenCalledWith("Some required site file fields are missing or incorrect.  Please fix these fields before submitting.");
+    expect(component.loading).toBeFalse();
+  });
+
+  it('should add housing type name to object and return', () => {
+    let response = {housing_type_id: 1};
+    component.siteHousingLookup = [{housing_type_id: 1, type_name: "test"}, {housing_type_id: 2, type_name: "test2"}]
+
+    let returnValue = component.getHousingType(response);
+    fixture.detectChanges();
+
+    expect(returnValue).toEqual({housing_type_id: 1, housingType: "test"});
+  });
+
+  it('should return return a filetype name', () => {
+    let response = 1;
+    component.fileTypes = [{filetype_id: 1, filetype: "photo"}, {filetype_id: 2, filetype: "link"}]
+
+    let returnValue = component.fileTypeLookup(response);
+    fixture.detectChanges();
+
+    expect(returnValue).toEqual("photo");
+  });
+
+  it('should convert lat/lng and submit new site info', () => {
+    component.latLngUnit = "decdeg";
+    component.siteForm.get("site_id").setValue(24224);
+    component.siteForm.get("site_description").setValue("test");
+    component.siteForm.get("county").setValue("Dane");
+    component.siteForm.get("hcollect_method_id").setValue(2);
+    component.siteForm.get("hdatum_id").setValue(2);
+    component.siteForm.get("state").setValue("WI");
+    component.siteForm.get("waterbody").setValue("test");
+    component.siteForm.get("siteHousings").value = (new FormArray([new FormGroup({housingType: new FormControl("test"), housing_type_id: new FormControl(1)})]));
+    component.housingTypeArray = ["test"]
+    component.data.networkName = undefined;
+    component.data.networkType = undefined;
+    component.networkTypes = [];
+    component.networkNames = [];
+
+    let siteResponse = {filetype_id: 8, file_date: "2018-12-29T22:55:17.129", site_id: 242224, description: "test file", file_id: 9999};
+    spyOn(component.siteEditService, 'putSite').and.returnValue(
+      of(siteResponse)
+    );
+    component.data.siteHousing = [{amount: 1, housing_type_id: 2, housingType: "testHousing", site_housing_id: 1}];
+    spyOn(component.siteEditService, 'deleteSiteHousings').and.returnValue(
+      of([])
+    );
+
+    component.putSite();
+    fixture.detectChanges();
+
+    expect(component.returnData.site).toEqual(siteResponse);
+
+    component.latLngUnit = "dms";
+    
+    component.siteForm.get('latdeg').setValue('47');
+    component.siteForm.get('latmin').setValue('26');
+    component.siteForm.get('latsec').setValue('30.012');
+    component.siteForm.get('londeg').setValue('-91');
+    component.siteForm.get('lonmin').setValue('44');
+    component.siteForm.get('lonsec').setValue('30.012');
+
+    component.putSite();
+    fixture.detectChanges();
+
+    expect(component.returnData.site).toEqual(siteResponse);
+    expect(component.siteForm.get('latitude_dd').value).toEqual('47.44167');
+    expect(component.siteForm.get('longitude_dd').value).toEqual('-91.74167');
+    expect(component.returnData.housings).toEqual([{amount: 1, housing_type_id: 1}]);
+  });
+
+  // it('should remove site housings', () => {
+  //   component.latLngUnit = "decdeg";
+  //   component.siteForm.get("site_id").setValue(24224);
+  //   component.siteForm.get("site_description").setValue("test");
+  //   component.siteForm.get("county").setValue("Dane");
+  //   component.siteForm.get("hcollect_method_id").setValue(2);
+  //   component.siteForm.get("hdatum_id").setValue(2);
+  //   component.siteForm.get("state").setValue("WI");
+  //   component.siteForm.get("waterbody").setValue("test");
+  //   component.siteForm.get("siteHousings").value = (new FormArray([new FormGroup({housingType: new FormControl("test"), housing_type_id: new FormControl(1)})]));
+  //   component.housingTypeArray = ["test"]
+  //   console.log(component.housingTypeArray)
+  //   component.data.siteHousing = [{amount: 1, housing_type_id: 2, housingType: "testHousing", site_housing_id: 1}];
+  //   spyOn(component.siteEditService, 'deleteSiteHousings').and.returnValue(
+  //     of([])
+  //   );
+  //   component.data.networkName = undefined;
+  //   component.data.networkType = undefined;
+  //   component.networkTypes = [];
+  //   component.networkNames = [];
+
+  //   component.putSite();
+  //   fixture.detectChanges();
+
+  //   expect(component.returnData.housings).toEqual([{amount: 1, housing_type_id: 1}]);
+  // });
+
+  // it('should validate lat dd value', () => {
+  //   component.siteForm.get('latitude_dd').setValue(47.44167);
+
+  //   component.checkLatValue();
+  //   fixture.detectChanges();
+  //   expect(component.siteForm.get('latitude_dd').valid).toBeTruthy();
+
+  //   component.siteForm.get("latitude_dd").setValue(-10);
+
+  //   component.checkLatValue();
+  //   fixture.detectChanges();
+  //   expect(component.siteForm.get('latitude_dd').valid).toBeFalsy();
+
+  //   component.siteForm.get("latitude_dd").setValue(null);
+
+  //   component.checkLatValue();
+  //   fixture.detectChanges();
+  //   expect(component.siteForm.get('latitude_dd').valid).toBeFalsy();
+  // });
+
+  // it('should validate lon dd value', () => {
+  //   component.siteForm.get('longitude_dd').setValue(-100);
+
+  //   component.checkLonValue();
+  //   fixture.detectChanges();
+  //   console.log(component.siteForm.get('longitude_dd'))
+  //   expect(component.siteForm.get('longitude_dd').valid).toBeTruthy();
+
+  //   component.siteForm.get("longitude_dd").setValue(-180);
+
+  //   component.checkLonValue();
+  //   fixture.detectChanges();
+  //   console.log(component.siteForm.get('longitude_dd'))
+  //   expect(component.siteForm.get('longitude_dd').valid).toBeFalsy();
+
+  //   component.siteForm.get("longitude_dd").setValue(null);
+
+  //   component.checkLonValue();
+  //   fixture.detectChanges();
+  //   console.log(component.siteForm.get('longitude_dd'))
+  //   expect(component.siteForm.get('longitude_dd').valid).toBeFalsy();
+  // });
+
+  // it('should validate lon deg value', () => {
+  //   component.siteForm.get('londeg').setValue(-100);
+
+  //   component.checkDDLonDegValue();
+  //   fixture.detectChanges();
+  //   console.log(component.siteForm.get('londeg'))
+  //   expect(component.siteForm.get('londeg').valid).toBeTruthy();
+
+  //   component.siteForm.get("londeg").setValue(-180);
+
+  //   component.checkDDLonDegValue();
+  //   fixture.detectChanges();
+  //   console.log(component.siteForm.get('londeg'))
+  //   expect(component.siteForm.get('londeg').valid).toBeFalsy();
+
+  //   component.siteForm.get("londeg").setValue(undefined);
+
+  //   component.checkDDLonDegValue();
+  //   fixture.detectChanges();
+  //   console.log(component.siteForm.get('londeg'))
+  //   expect(component.siteForm.get('londeg').valid).toBeFalsy();
+  // });
+
+  // it('should validate lat deg value', () => {
+  //   component.siteForm.get('latdeg').setValue(47.44167);
+
+  //   component.checkDDLatDegValue();
+  //   fixture.detectChanges();
+  //   console.log(component.siteForm.get('latdeg'))
+  //   expect(component.siteForm.get('latdeg').valid).toBeTruthy();
+
+  //   component.siteForm.get("latdeg").setValue(-10);
+
+  //   component.checkDDLatDegValue();
+  //   fixture.detectChanges();
+  //   console.log(component.siteForm.get('latdeg'))
+  //   expect(component.siteForm.get('latdeg').valid).toBeFalsy();
+
+  //   component.siteForm.get("latdeg").setValue(undefined);
+
+  //   component.checkDDLatDegValue();
+  //   fixture.detectChanges();
+  //   console.log(component.siteForm.get('latdeg'))
+  //   expect(component.siteForm.get('latdeg').valid).toBeFalsy();
+  // });
 });

--- a/src/app/site-edit/site-edit.component.spec.ts
+++ b/src/app/site-edit/site-edit.component.spec.ts
@@ -1,14 +1,72 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialogModule } from '@angular/material/dialog';
+import { SiteService } from '@app/services/site.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { MatTableModule } from '@angular/material/table';
 
 import { SiteEditComponent } from './site-edit.component';
+import { of } from 'rxjs';
+import { APP_SETTINGS } from '@app/app.settings';
 
 describe('SiteEditComponent', () => {
   let component: SiteEditComponent;
   let fixture: ComponentFixture<SiteEditComponent>;
 
+  const dialogMock = {
+    close: () => {},
+  };
+
+  const data = 
+    {  
+      site: {
+        description: null,
+        internal_notes: null,
+        latitude_dd: null,
+        longitude_dd: null,
+        hdatum_id: null,
+        hcollect_method_id: null,
+        waterbody: null,
+        drainage_area: null,
+        usgs_id: null,
+        noaa_id: null,
+        other_id: null,
+        safety_notes: null,
+        zone: null,
+        address: null,
+        city: null,
+        state: "AL",
+        county: null,
+        zip: null,
+        memberName: null,
+        priority_id: null,
+      },
+      networkType: null,
+      networkName: null,
+      hdatumList: null,
+      hmethodList: null,
+      siteFiles: null,
+      siteHousing: [],
+      memberName: 0,
+      priority: 1,
+      landowner: null,
+    }
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ SiteEditComponent ]
+      declarations: [ SiteEditComponent ],
+      providers: [
+        SiteService,
+        { provide: MatDialogRef, useValue: dialogMock },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+      ],
+      imports: [
+        MatDialogModule,
+        HttpClientTestingModule,
+        MatTableModule,
+      ],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
     })
     .compileComponents();
   });
@@ -22,4 +80,417 @@ describe('SiteEditComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should set the networkTypes lookup', () => {
+    const response: any[] = [{network_type_name: "test", selected: false}];
+
+    spyOn(component.siteService, 'getNetworkTypesList').and.returnValue(
+        of(response)
+    );
+
+    component.getNetworkTypes();
+    fixture.detectChanges();
+    expect(component.networkTypes).toEqual(response);
+  });
+
+  it('networkType should be selected and new form control added', () => {
+    const response: any[] = [{network_type_name: "test"}];
+    data.networkType = "test";
+
+    spyOn(component.siteService, 'getNetworkTypesList').and.returnValue(
+        of(response)
+    );
+
+    component.getNetworkTypes();
+    fixture.detectChanges();
+    expect(component.networkTypes).toEqual([{network_type_name: "test", selected: true}]);
+    expect(component.selectedNetworkTypes.length).toEqual(1);
+    expect(component.siteForm.controls.networkType.length).toEqual(1);
+
+    data.networkType = null;
+  });
+
+  it('should set the networkNames lookup', () => {
+    const response: any[] = [{name: "test"}];
+
+    spyOn(component.siteService, 'getNetworkNamesList').and.returnValue(
+        of(response)
+    );
+
+    component.getNetworkNames();
+    fixture.detectChanges();
+    expect(component.networkNames).toEqual([{name: "test", selected: false}]);
+  });
+
+  it('networkName should be selected and new form control added', () => {
+    const response: any[] = [{name: "test"}];
+    data.networkName = "test";
+
+    spyOn(component.siteService, 'getNetworkNamesList').and.returnValue(
+        of(response)
+    );
+
+    component.getNetworkNames();
+    fixture.detectChanges();
+    expect(component.networkNames).toEqual([{name: "test", selected: true}]);
+    expect(component.selectedNetworkNames.length).toEqual(1);
+    expect(component.siteForm.controls.networkName.length).toEqual(1);
+
+    data.networkName = null;
+  });
+
+  it('if networkName is Not Defined initially, disable all other checkboxes', () => {
+    const response: any[] = [{name: "Not Defined"}, {name: "test"}];
+    data.networkName = "Not Defined";
+    
+    spyOn(component.siteService, 'getNetworkNamesList').and.returnValue(
+        of(response)
+    );
+
+    component.getNetworkNames();
+    fixture.detectChanges();
+    expect(component.isDisabled).toBeTrue;
+    expect(component.selectedNetworkNames.length).toEqual(1);
+    expect(component.siteForm.controls.networkName.length).toEqual(1);
+    expect(component.networkNames).toEqual([{name: "Not Defined", selected: true}, {name: "test", selected: false}])
+
+    data.networkName = null;
+  });
+
+  it('should set the form values for checked network types', () => {
+    let data = {network_type_name: "test network", selected: false};
+    let event = {checked: true};
+    component.selectedNetworkTypes = ["test1", "test2"];
+
+    // checked
+    component.setSelectedNetworkType(event, data);
+    fixture.detectChanges();
+    expect(data.selected).toEqual(true);
+    expect(component.selectedNetworkTypes.length).toEqual(3);
+
+    // unchecked
+    data = {network_type_name: "test network", selected: true};
+    event = {checked: false};
+
+    component.setSelectedNetworkType(event, data);
+    fixture.detectChanges();
+    expect(data.selected).toEqual(false);
+    expect(component.selectedNetworkTypes.length).toEqual(2);
+  });
+
+  it('should set the form values for checked network names', () => {
+    let data = {name: "Not Defined", selected: false};
+    component.networkNames = [{name: "Not Defined", selected: false}, {name: "test1", selected: true}, {name: "test2", selected: true}];
+    let event = {checked: true};
+    component.selectedNetworkNames = ["test1", "test2"];
+
+    // checked
+    component.setSelectedNetworkName(event, data);
+    fixture.detectChanges();
+    expect(data.selected).toEqual(true);
+    expect(component.isDisabled).toBeTrue;
+    expect(component.selectedNetworkNames.length).toEqual(1);
+    expect(component.networkNames[0].selected).toEqual(true);
+    expect(component.networkNames[1].selected).toEqual(false);
+    expect(component.networkNames[2].selected).toEqual(false);
+
+    // unchecked
+    data = {name: "Not Defined", selected: true};
+    event = {checked: false};
+
+    component.setSelectedNetworkName(event, data);
+    fixture.detectChanges();
+    expect(data.selected).toEqual(false);
+    expect(component.selectedNetworkNames.length).toEqual(0);
+    expect(component.isDisabled).toBeFalse;
+  });
+
+  xit('should add or remove rows in the housing type table', () => {
+    // Add values
+    let value = ["test3"];
+
+    component.changeTableValue(value);
+    fixture.detectChanges();
+    expect(component.siteHousingArray.length).toEqual(1);
+
+    // Remove value
+    value = ["test3"]
+    component.changeTableValue(value);
+    fixture.detectChanges();
+    expect(component.siteHousingArray.length).toEqual(0);
+  });
+
+  it('should set the agency lookup', () => {
+    const response: any[] = [{agency: "test"}];
+
+    spyOn(component.siteService, 'getAgencyLookup').and.returnValue(
+        of(response)
+    );
+
+    component.getAgencies();
+    fixture.detectChanges();
+    expect(component.agencies).toEqual(response);
+  });
+
+  it('should set the priority lookup', () => {
+    const response: any[] = [{priority_id: 1}];
+    
+    spyOn(component.siteService, 'getPriorities').and.returnValue(
+        of(response)
+    );
+
+    component.getPriorities();
+    fixture.detectChanges();
+    expect(component.priorityList).toEqual(response);
+  });
+
+  it('should set the file type lookup', () => {
+    const response: any[] = [{filetype: "Photo"}];
+    
+    spyOn(component.siteService, 'getFileTypeLookup').and.returnValue(
+        of(response)
+    );
+
+    component.getFileTypes();
+    fixture.detectChanges();
+    expect(component.fileTypes).toEqual(response);
+  });
+
+  it('should set the site housing lookup', () => {
+    const response: any[] = [{housingType: "test"}];
+    
+    spyOn(component.siteService, 'getAllHousingTypes').and.returnValue(
+        of(response)
+    );
+
+    component.getSiteHousings();
+    fixture.detectChanges();
+    expect(component.siteHousingLookup).toEqual(response);
+  });
+
+  it('should set the state lookup', () => {
+    const response: any[] = [{state_name: "Alabama", state_abbrev: "AL"}];
+    
+    spyOn(component.siteService, 'getAllStates').and.returnValue(
+        of(response)
+    );
+
+    component.getStateList();
+    fixture.detectChanges();
+    expect(component.stateList).toEqual(response);
+    expect(component.siteForm.controls['state'].value).toEqual("Alabama");
+  });
+
+  it('should set the county lookup', () => {
+    const response: any[] = ["county1", "county2"];
+    component.stateList = [{state_name: "Alabama", state_id: 1}, {state_name: "Idaho", state_id: 2}];
+    
+    spyOn(component.siteService, 'getAllCounties').and.returnValue(
+        of(response)
+    );
+
+    component.getCountyList("Alabama");
+    fixture.detectChanges();
+    expect(component.countyList).toEqual(response);
+  });
+
+  it('should add landowner contact', () => {
+    component.addLandownerContact();
+    fixture.detectChanges();
+    expect(component.addLandownerCheck).toBeTrue;
+  });
+
+  it('should set LO address to site address', () => {
+    component.useSiteAddress = false;
+    component.site.address = "000 Test Street";
+    component.site.city = "Test City";
+    component.site.state = "Alabama";
+    component.site.zip = "00000";
+
+    component.useAddressforLO();
+    fixture.detectChanges();
+    expect(component.landownerForm.dirty).toBeTrue;
+    expect(component.useSiteAddress).toBeTrue;
+    expect(component.landownerContact.address).toEqual("000 Test Street");
+    expect(component.landownerContact.city).toEqual("Test City");
+    expect(component.landownerContact.state).toEqual("Alabama");
+    expect(component.landownerContact.zip).toEqual("00000");
+    expect(component.landownerForm.controls['address'].value).toEqual("000 Test Street");
+    expect(component.landownerForm.controls['city'].value).toEqual("Test City");
+    expect(component.landownerForm.controls['state'].value).toEqual("Alabama");
+    expect(component.landownerForm.controls['zip'].value).toEqual("00000");
+  });
+
+  it('should remove site address from LO address', () => {
+    component.useSiteAddress = true;
+    component.site.address = "000 Test Street";
+    component.site.city = "Test City";
+    component.site.state = "Alabama";
+    component.site.zip = "00000";
+
+    component.useAddressforLO();
+    fixture.detectChanges();
+    expect(component.landownerForm.dirty).toBeTrue;
+    expect(component.useSiteAddress).toBeFalse;
+    expect(component.landownerContact.address).toEqual("");
+    expect(component.landownerContact.city).toEqual("");
+    expect(component.landownerContact.state).toEqual("");
+    expect(component.landownerContact.zip).toEqual("");
+    expect(component.landownerForm.controls['address'].value).toEqual("");
+    expect(component.landownerForm.controls['city'].value).toEqual("");
+    expect(component.landownerForm.controls['state'].value).toEqual("");
+    expect(component.landownerForm.controls['zip'].value).toEqual("");
+  });
+
+  it('should format date', () => {
+    const testDate = {value: new Date("November 20, 2021 11:00:00")};
+
+    component.formatDate(testDate);
+    fixture.detectChanges();
+    expect(component.formattedPhotoDate).toEqual("11/20/2021");
+  });
+
+  it('should convert dd to dms', () => {
+    let lat = 45.86;
+
+    let dmsLat = component.deg_to_dms(lat);
+    fixture.detectChanges();
+    expect(dmsLat).toEqual("45:51:36.000");
+
+    let lon = -91.86;
+
+    let dmsLon = component.deg_to_dms(lon);
+    fixture.detectChanges();
+    expect(dmsLon).toEqual("91:51:36.000");
+  });
+
+  it('should convert dms to dd', () => {
+    let deg = 45;
+    let min = 51;
+    let sec = 36.000;
+
+    let latDMS = component.azimuth(deg, min, sec);
+    fixture.detectChanges();
+    expect(latDMS).toEqual("45.86000");
+
+    deg = -91;
+    min = 51;
+    sec = 36.000;
+
+    let lonDMS = component.azimuth(deg, min, sec);
+    fixture.detectChanges();
+    expect(lonDMS).toEqual("-91.86000");
+  });
+
+  it('should set the agency name for the preview caption', () => {
+    component.siteFileForm.controls["filetype_id"].value = 1;
+    component.siteFileForm.controls["agency_id"].value = 0;
+    component.agencies = [{agency_name: "WIM", agency_id: 0}];
+    component.updateAgencyForCaption();
+    fixture.detectChanges();
+    expect(component.agencyNameForCap).toEqual("WIM");
+  });
+
+  it('sensor not appropriate should disable permanent housing installed and set value to No', () => {
+    let event = {checked: true};
+    component.sensorAppropriateChanged(event);
+    fixture.detectChanges();
+    expect(component.perm_housing_installed).toEqual("No");
+    expect(component.siteForm.controls['is_permanent_housing_installed'].value).toEqual("No");
+    expect(component.siteForm.controls['is_permanent_housing_installed'].disabled).toEqual(true);
+
+    // should enable permanent housing when unchecked
+    event = {checked: false};
+    component.sensorAppropriateChanged(event);
+    fixture.detectChanges();
+    expect(component.siteForm.controls['is_permanent_housing_installed'].disabled).toEqual(false);
+  });
+
+  it('should reset and show file edit form', () => {
+    let row = {filetype_id: 1, file_id: 1, source_id: 1, file_date: new Date(), photo_date: new Date(), photo_direction: "", latitude_dd: 45.86, longitude_dd: -87.60, name: "filename.jpg"};
+    let cancelFileSpy = spyOn(component, 'cancelFile');
+    let setInitFile = spyOn(component, 'setInitFileEditForm');
+    let getFileSpy = spyOn(component, 'getFile');
+
+    component.showFileEdit(row);
+    fixture.detectChanges();
+    expect(cancelFileSpy).toHaveBeenCalled;
+    expect(setInitFile).toHaveBeenCalled;
+    expect(component.addFileType).toEqual("Existing");
+    expect(getFileSpy).toHaveBeenCalled;
+    expect(component.siteFiles.source_id).toEqual(1);
+    expect(component.siteFiles.file_id).toEqual(1);
+    expect(component.siteFiles.filetype_id).toEqual(1);
+    expect(component.siteFiles.file_date).toEqual(row.file_date);
+    expect(component.siteFiles.photo_date).toEqual(row.photo_date);
+    expect(component.siteFiles.photo_direction).toEqual(null);
+    expect(component.siteFiles.latitude_dd).toEqual(45.86);
+    expect(component.siteFiles.longitude_dd).toEqual(-87.60);
+  });
+
+  it('set initial file edit form control values', () => {
+    let data = {filetype_id: 1, file_id: 1, source_id: 1, file_date: new Date(), photo_date: new Date(), photo_direction: "", latitude_dd: 45.86, longitude_dd: -87.60, name: "filename.jpg"};
+
+    component.setInitFileEditForm(data);
+    fixture.detectChanges();
+    expect(component.siteFileForm.controls.source_id.value).toEqual(1);
+    expect(component.siteFileForm.controls.file_id.value).toEqual(1);
+    expect(component.siteFileForm.controls.filetype_id.value).toEqual(1);
+    expect(component.siteFileForm.controls.file_date.value).toEqual(data.file_date);
+    expect(component.siteFileForm.controls.photo_date.value).toEqual(data.photo_date);
+    expect(component.siteFileForm.controls.photo_direction.value).toEqual("");
+    expect(component.siteFileForm.controls.latitude_dd.value).toEqual(45.86);
+    expect(component.siteFileForm.controls.longitude_dd.value).toEqual(-87.60);
+  });
+
+  it('should get the file item name', () => {
+    component.siteFiles.file_id = 1;
+    const response = {FileName: "testFile"};
+    
+    spyOn(component.siteService, 'getFileItem').and.returnValue(
+        of(response)
+    );
+
+    let fileAgencySpy = spyOn(component, 'setFileSourceAgency');
+    let fileSourceSpy = spyOn(component, 'setFileSource');
+
+    component.getFile();
+    fixture.detectChanges();
+    expect(component.fileItemExists).toEqual(true);
+    expect(component.fileSource).toEqual(APP_SETTINGS.API_ROOT + 'Files/1/item')
+    expect(component.siteFiles.name).toEqual("testFile");
+    expect(component.siteFileForm.controls.name.value).toEqual("testFile");
+    expect(fileAgencySpy).toHaveBeenCalled;
+    expect(fileSourceSpy).toHaveBeenCalled;
+  });
+
+  it('should set the file source agency', () => {
+    component.siteFiles.source_id = 1;
+    const response = {agency_name: "WIM", agency_id: 0};
+    
+    spyOn(component.siteService, 'getFileSource').and.returnValue(
+        of(response)
+    );
+
+    component.setFileSourceAgency();
+    fixture.detectChanges();
+    expect(component.agencyNameForCap).toEqual("WIM");
+    expect(component.siteFiles.agency_id).toEqual(0);
+    expect(component.siteFileForm.controls.agency_id.value).toEqual(0);
+  });
+
+  it('should set the file source', () => {
+    component.siteFiles.source_id = 1;
+    const response = {source_name: "John Smith"};
+    
+    spyOn(component.siteService, 'getSourceName').and.returnValue(
+        of(response)
+    );
+
+    component.setFileSource();
+    fixture.detectChanges();
+    expect(component.siteFiles.FULLname).toEqual("John Smith");
+    expect(component.siteFileForm.controls.FULLname.value).toEqual("John Smith");
+  });
+
 });

--- a/src/app/site-edit/site-edit.component.ts
+++ b/src/app/site-edit/site-edit.component.ts
@@ -1,0 +1,209 @@
+import { L } from '@angular/cdk/keycodes';
+import { Component, Inject, OnInit } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { SiteService } from '@app/services/site.service';
+
+@Component({
+  selector: 'app-site-edit',
+  templateUrl: './site-edit.component.html',
+  styleUrls: ['./site-edit.component.scss']
+})
+export class SiteEditComponent implements OnInit {
+  public networkTypes;
+  public networkNames;
+  public hDatums;
+  public hMethods;
+  public priorities;
+  public siteHousings;
+  public stateList;
+  public countyList;
+  public perm_housing_installed;
+  public sensorNotAppropriate;
+  public accessGranted;
+  public siteHousingArray = [];
+  public siteHousingLookup;
+  public site = {
+    description: null,
+    internal_notes: null,
+    latitude_dd: null,
+    longitude_dd: null,
+    hdatum: null,
+    hmethod: null,
+    waterbody: null,
+    drainage_area: null,
+    usgs_id: null,
+    noaa_id: null,
+    other_id: null,
+    safety_notes: null,
+    zone: null,
+    address: null,
+    city: null,
+    state: null,
+    county: null,
+    zip: null,
+    memberName: null,
+  };
+
+  siteForm;
+  
+  displayedColumns: string[] = [
+    'HousingType',
+    'HousingLength',
+    'HousingMaterial',
+    'Amount',
+    'Notes',
+  ];
+
+  constructor(
+    private dialogRef: MatDialogRef<SiteEditComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: any,
+    public siteService: SiteService,
+  ) { }
+
+  ngOnInit(): void {
+    console.log(this.data.site)
+    this.hDatums = this.data.hdatumList;
+    this.hMethods = this.data.hmethodList;
+    this.getNetworkTypes();
+    this.getNetworkNames();
+    this.setInitialSite();
+    this.getSiteHousings();
+
+    this.siteForm = new FormGroup({
+      site_description: new FormControl(this.site.description),
+      site_notes: new FormControl(this.site.internal_notes),
+      latitude_dd: new FormControl(this.site.latitude_dd),
+      longitude_dd: new FormControl(this.site.longitude_dd),
+      is_permanent_housing_installed: new FormControl(this.perm_housing_installed),
+      access_granted: new FormControl(this.accessGranted),
+      hdatum: new FormControl(this.site.hdatum),
+      hmethod: new FormControl(this.site.hmethod),
+      waterbody: new FormControl(this.site.waterbody),
+      drainage_area_sqmi: new FormControl(this.site.drainage_area),
+      usgs_sid: new FormControl(this.site.usgs_id),
+      noaa_sid: new FormControl(this.site.noaa_id),
+      other_sid: new FormControl(this.site.other_id),
+      safety_notes: new FormControl(this.site.safety_notes),
+      zone: new FormControl(this.site.zone),
+      address: new FormControl(this.site.address),
+      city: new FormControl(this.site.city),
+      state: new FormControl(this.site.state),
+      county: new FormControl(this.site.county),
+      zip: new FormControl(this.site.zip),
+    });
+  }
+
+  getNetworkTypes() {
+    let self = this;
+    this.siteService.getNetworkTypesList().subscribe((results) => {
+      results.forEach(function(result){
+        if (self.data.networkType !== undefined && self.data.networkType.includes(result.network_type_name)){
+          result.selected = true;
+        }else{
+          result.selected = false;
+        }
+      })
+      this.networkTypes = results;
+    });
+  }
+
+  getNetworkNames() {
+    let self = this;
+    this.siteService.getNetworkNamesList().subscribe((results) => {
+      results.forEach(function(result){
+        if (self.data.networkName !== undefined && self.data.networkName.includes(result.name)){
+          result.selected = true;
+        }else{
+          result.selected = false;
+        }
+      })
+      this.networkNames = results;
+    });
+  }
+
+  getSiteHousings() {
+    this.siteService.getAllHousingTypes().subscribe((results) => {
+      this.siteHousingLookup = results;
+    });
+  }
+
+  setSelected(event, data) {
+    data.selected = event.checked;
+  }
+
+  changeTableValue(value){
+    this.siteHousingArray[0].housingType = value;
+  }
+
+  // Populate site info initially with existing site info
+  setInitialSite() {
+    this.site.description =  this.data.site.site_description !== undefined && this.data.site.site_description !== "" ? this.data.site.site_description : null;
+    this.site.latitude_dd = this.data.site.latitude_dd !== undefined && this.data.site.latitude_dd !== "" ? this.data.site.latitude_dd : null;
+    this.site.longitude_dd = this.data.site.longitude_dd !== undefined && this.data.site.longitude_dd !== "" ? this.data.site.longitude_dd : null;
+    this.site.hdatum = this.data.hdatum !== undefined && this.data.hdatum !== "" ? this.data.hdatum : null;
+    this.site.hmethod = this.data.hmethod !== undefined && this.data.hmethod !== "" ? this.data.hmethod : null;
+    this.site.waterbody = this.data.site.waterbody !== undefined && this.data.site.waterbody !== "" ? this.data.site.waterbody : null;
+    this.site.safety_notes = this.data.site.safety_notes !== undefined && this.data.site.safety_notes !== "" ? this.data.site.safety_notes : null;
+    this.site.zone = this.data.site.zone !== undefined && this.data.site.zone !== "" ? this.data.site.zone : null;
+    this.site.usgs_id = this.data.site.usgs_sid !== undefined && this.data.site.usgs_sid !== "" ? this.data.site.usgs_sid : null;
+    this.site.noaa_id = this.data.site.noaa_sid !== undefined && this.data.site.noaa_sid !== "" ? this.data.site.noaa_sid : null;
+    this.site.other_id = this.data.site.other_sid !== undefined && this.data.site.other_sid !== "" ? this.data.site.other_sid : null;
+    this.site.internal_notes = this.data.site.site_notes !== undefined && this.data.site.site_notes !== "" ? this.data.site.site_notes : null;
+    this.site.drainage_area = this.data.site.drainage_area_sqmi !== undefined && this.data.site.drainage_area_sqmi !== "" ? this.data.site.drainage_area_sqmi : null;
+    this.site.address = this.data.site.address !== undefined && this.data.site.address !== "" ? this.data.site.address : null;
+    this.site.county = this.data.site.county !== undefined && this.data.site.county !== "" ? this.data.site.county : null;
+    this.site.city = this.data.site.city !== undefined && this.data.site.city !== "" ? this.data.site.city : null;
+    this.site.zip = this.data.site.zip !== undefined && this.data.site.zip !== "" ? this.data.site.zip : null;
+    this.site.memberName = this.data.memberName !== undefined && this.data.memberName !== "---" && this.data.memberName !== "" ? this.data.memberName : null;
+    this.siteHousingArray = this.data.siteHousing;
+    
+    this.perm_housing_installed = this.data.site.is_permanent_housing_installed !== undefined && this.data.site.is_permanent_housing_installed === "Yes" ? "Yes" : "No";
+    this.sensorNotAppropriate = this.data.site.sensor_not_appropriate !== undefined && this.sensorNotAppropriate === 1 ? true : false;
+    if (this.data.site.access_granted !== undefined){
+      if(this.data.site.access_granted === "Yes"){
+        this.accessGranted = "Yes";
+      } else if(this.data.site.access_granted === "No"){
+        this.accessGranted = "No";
+      } else{
+        this.accessGranted = "Not Needed";
+      }
+    }
+    this.getStateList();
+  }
+
+  getStateList() {
+    let self = this;
+    this.siteService.getAllStates().subscribe((results) => {
+      this.stateList = results;
+      if(this.data.site.state !== undefined && this.data.site.state !== ""){
+        this.stateList.forEach(function(state){
+          if(state.state_abbrev === self.data.site.state){
+            self.site.state = state.state_name;
+            self.getCountyList(self.site.state);
+          }
+        });
+      }
+    });
+  }
+
+  getCountyList(stateName) {
+      let self = this;
+      let stateID;
+      this.stateList.forEach(function(state){
+        if(stateName === state.state_name){
+          stateID = state.state_id;
+          self.siteService.getAllCounties(stateID).subscribe((results) => {
+            self.countyList = results;
+          });
+          if(stateName !== self.site.state){
+            self.site.county = null;
+          }
+        }
+      })
+  }
+
+  submitSiteForm(){
+    console.log("submitted!");
+  }
+}

--- a/src/app/site-edit/site-edit.component.ts
+++ b/src/app/site-edit/site-edit.component.ts
@@ -1,8 +1,14 @@
 import { L } from '@angular/cdk/keycodes';
-import { Component, Inject, OnInit } from '@angular/core';
-import { FormControl, FormGroup } from '@angular/forms';
+import { GlobalPositionStrategy } from '@angular/cdk/overlay';
+import { HttpErrorResponse } from '@angular/common/http';
+import { ConditionalExpr } from '@angular/compiler';
+import { ChangeDetectorRef, Component, ElementRef, Inject, OnInit, ViewChild } from '@angular/core';
+import { AbstractControl, FormArray, FormControl, FormGroup, ValidationErrors, Validators } from '@angular/forms';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { NetworkNameService } from '@app/services/network-name.service';
+import { SiteEditService } from '@app/services/site-edit.service';
 import { SiteService } from '@app/services/site.service';
+import { APP_SETTINGS } from '../app.settings';
 
 @Component({
   selector: 'app-site-edit',
@@ -10,11 +16,14 @@ import { SiteService } from '@app/services/site.service';
   styleUrls: ['./site-edit.component.scss']
 })
 export class SiteEditComponent implements OnInit {
+  @ViewChild('upload', {static: false}) upload: ElementRef;
+
   public networkTypes;
   public networkNames;
+  public selectedNetworkTypes = [];
+  public selectedNetworkNames = [];
   public hDatums;
   public hMethods;
-  public priorities;
   public siteHousings;
   public stateList;
   public countyList;
@@ -22,7 +31,53 @@ export class SiteEditComponent implements OnInit {
   public sensorNotAppropriate;
   public accessGranted;
   public siteHousingArray = [];
+  public housingTypeArray = [];
   public siteHousingLookup;
+  public fileTypes = [];
+  public initSiteFiles = [];
+  public priority;
+  public priorityList = [];
+  public latLngUnit = 'decdeg';
+  public agencies = [];
+  public agencyNameForCap;
+  public formattedPhotoDate;
+  public fileSource;
+  public addFileType;
+  public valid;
+  public landownerValid;
+  public fileValid;
+  // public existingFile = {
+  //   file_id: null,
+  //   filetype_id: null,
+  // };
+  public dms = {
+    latdeg: null,
+    latmin: null,
+    latsec: null,
+    londeg: null,
+    lonmin: null,
+    lonsec: null,
+  }
+  public siteFiles = {
+    file_id: null,
+    name: null,
+    FULLname: null,
+    description: null,
+    file_date: null,
+    photo_date: null,
+    agency_id: null,
+    site_id: null,
+    filetype_id: null,
+    path: null,
+    data_file_id: null,
+    instrument_id: null,
+    last_updated: null,
+    last_updated_by: null,
+    site_description: null,
+    photo_direction: null,
+    latitude_dd: null,
+    longitude_dd: null,
+  };
   public site = {
     description: null,
     internal_notes: null,
@@ -43,9 +98,34 @@ export class SiteEditComponent implements OnInit {
     county: null,
     zip: null,
     memberName: null,
+    priority_id: null,
   };
 
+  public landownerContact = {
+    lname: null,
+    fname: null,
+    title: null,
+    address: null,
+    city: null,
+    state: null,
+    zip: null,
+    primaryphone: null,
+    secondaryphone: null,
+    email: null,
+  }
+
   siteForm;
+  landownerForm;
+  siteFileForm;
+
+  public hasLandownerContact = false;
+  public addLandownerCheck = false;
+  public useSiteAddress = false;
+  public showFileForm = false;
+  public incorrectDMS = false;
+  public isDisabled = false;
+  public permHousingDisabled = false;
+  public fileItemExists = false;
   
   displayedColumns: string[] = [
     'HousingType',
@@ -55,43 +135,32 @@ export class SiteEditComponent implements OnInit {
     'Notes',
   ];
 
+  displayedFileColumns: string[] = [
+    'FileName',
+    'FileDate',
+  ];
+
   constructor(
     private dialogRef: MatDialogRef<SiteEditComponent>,
     @Inject(MAT_DIALOG_DATA) public data: any,
     public siteService: SiteService,
+    public siteEditService: SiteEditService,
+    private changeDetector : ChangeDetectorRef,
   ) { }
 
   ngOnInit(): void {
-    console.log(this.data.site)
     this.hDatums = this.data.hdatumList;
     this.hMethods = this.data.hmethodList;
     this.getNetworkTypes();
     this.getNetworkNames();
+    this.getAgencies();
+    this.getFileTypes();
+    this.getPriorities();
     this.setInitialSite();
     this.getSiteHousings();
-
-    this.siteForm = new FormGroup({
-      site_description: new FormControl(this.site.description),
-      site_notes: new FormControl(this.site.internal_notes),
-      latitude_dd: new FormControl(this.site.latitude_dd),
-      longitude_dd: new FormControl(this.site.longitude_dd),
-      is_permanent_housing_installed: new FormControl(this.perm_housing_installed),
-      access_granted: new FormControl(this.accessGranted),
-      hdatum: new FormControl(this.site.hdatum),
-      hmethod: new FormControl(this.site.hmethod),
-      waterbody: new FormControl(this.site.waterbody),
-      drainage_area_sqmi: new FormControl(this.site.drainage_area),
-      usgs_sid: new FormControl(this.site.usgs_id),
-      noaa_sid: new FormControl(this.site.noaa_id),
-      other_sid: new FormControl(this.site.other_id),
-      safety_notes: new FormControl(this.site.safety_notes),
-      zone: new FormControl(this.site.zone),
-      address: new FormControl(this.site.address),
-      city: new FormControl(this.site.city),
-      state: new FormControl(this.site.state),
-      county: new FormControl(this.site.county),
-      zip: new FormControl(this.site.zip),
-    });
+    this.initSiteForm();
+    this.initLandownerForm();
+    this.initSiteFileForm();
   }
 
   getNetworkTypes() {
@@ -100,6 +169,8 @@ export class SiteEditComponent implements OnInit {
       results.forEach(function(result){
         if (self.data.networkType !== undefined && self.data.networkType.includes(result.network_type_name)){
           result.selected = true;
+          self.selectedNetworkTypes.push(result.network_type_name)
+          self.siteForm.controls.networkType.push(new FormControl(result.network_type_name));
         }else{
           result.selected = false;
         }
@@ -114,11 +185,51 @@ export class SiteEditComponent implements OnInit {
       results.forEach(function(result){
         if (self.data.networkName !== undefined && self.data.networkName.includes(result.name)){
           result.selected = true;
+          self.selectedNetworkNames.push(result.name);
+          if(result.name === "Not Defined"){
+            this.isDisabled = true;
+          }
+          self.siteForm.controls.networkName.push(new FormControl(result.name));
         }else{
           result.selected = false;
         }
       })
       this.networkNames = results;
+      // Disable and deselect other checkboxes if Not Defined
+      if(this.isDisabled == true){
+        this.siteForm.controls.networkName.clear();
+        this.selectedNetworkNames = ["Not Defined"];
+        this.siteForm.controls.networkName.push(new FormControl("Not Defined"));
+
+        this.networkNames.forEach(function(name){
+          if (name.name !== "Not Defined"){
+            name.selected = false;
+          }
+        })
+      }
+    });
+  }
+
+  getAgencies() {
+    this.siteService.getAgencyLookup().subscribe((results) => {
+      this.agencies = results;
+    });
+  }
+
+  getPriorities() {
+    this.siteService.getPriorities().subscribe((results) => {
+      this.priorityList = results;
+    });
+  }
+
+  getFileTypes() {
+    let self = this;
+    this.siteService.getFileTypeLookup().subscribe((results) => {
+      results.forEach(function(results){
+        if (results.filetype !== 'Data' && results.filetype !== 'NGS Datasheet'){
+          self.fileTypes.push(results);
+        }
+      })
     });
   }
 
@@ -128,16 +239,97 @@ export class SiteEditComponent implements OnInit {
     });
   }
 
-  setSelected(event, data) {
+  setSelectedNetworkType(event, data) {
     data.selected = event.checked;
+    let self = this;
+    // Add to or remove from form array to submit
+    if(data.selected && !(this.selectedNetworkTypes.join(',').includes(data.network_type_name))){
+      this.selectedNetworkTypes.push(data.network_type_name);
+      this.siteForm.controls.networkType.push(new FormControl(data.network_type_name));
+    }else if(!data.selected && (this.selectedNetworkTypes.join(',').includes(data.network_type_name))){
+      this.selectedNetworkTypes.splice(this.selectedNetworkTypes.indexOf(data.network_type_name), 1)
+      this.siteForm.controls.networkType.controls.forEach(function(control, i){
+        if(control.value === data.network_type_name){
+          self.siteForm.controls.networkType.removeAt(i);
+        }
+      });
+    }
+  }
+
+  setSelectedNetworkName(event, data) {
+    data.selected = event.checked;
+    let self = this;
+    // Add to or remove from form array to submit
+    if(data.selected && !(this.selectedNetworkNames.join(',').includes(data.name))){
+      this.selectedNetworkNames.push(data.name);
+      this.siteForm.controls.networkName.push(new FormControl(data.name));
+    }else if(!data.selected && (this.selectedNetworkNames.join(',').includes(data.name))){
+      this.selectedNetworkNames.splice(this.selectedNetworkNames.indexOf(data.name), 1)
+      this.siteForm.controls.networkName.controls.forEach(function(control, i){
+        if(control.value === data.name){
+          self.siteForm.controls.networkName.removeAt(i);
+        }
+      });
+    }
+    // Disable other checkboxes if undefined is checked
+    if(data.selected && data.name === "Not Defined"){
+      this.isDisabled = true;
+      this.siteForm.controls.networkName.clear();
+      this.selectedNetworkNames = [data.name];
+      this.siteForm.controls.networkName.push(new FormControl(data.name));
+      this.networkNames.forEach(function(name){
+        if (name.name !== data.name){
+          name.selected = false;
+        }
+      })
+    }else{
+      this.isDisabled = false;
+    }
   }
 
   changeTableValue(value){
-    this.siteHousingArray[0].housingType = value;
+    let newObject = {
+      amount: null,
+      housingType: null,
+      length: null,
+      material: null,
+      notes: null,
+    }
+    let self = this;
+    // If no housing types, only 1 value exists
+    if(this.siteHousingArray.length === 0){
+      newObject.housingType = value[0];
+      // Add to housing table array
+      this.siteHousingArray.push(newObject);
+      // Populate the dropdown value
+      this.housingTypeArray.push(value[0]);
+    // Compare with existing housing types in table
+    }else{
+      value.forEach(function(type){
+        if(!self.housingTypeArray.join(',').includes(type)){
+          newObject.housingType = type;
+          self.housingTypeArray.push(type);
+          self.siteHousingArray.push(newObject);
+        }
+      })
+      this.housingTypeArray.forEach(function(type){
+        if(!value.join(',').includes(type)){
+          self.housingTypeArray.splice(self.housingTypeArray.indexOf(type), 1);
+          self.siteHousingArray.forEach(function(housing){
+            if(housing.housingType === type){
+              self.siteHousingArray.splice(self.siteHousingArray.indexOf(housing), 1);
+            }
+          })
+        }
+      })
+    }
+    this.siteForm.controls['housingType'].setValue(this.housingTypeArray);
+    this.siteHousingArray = [...this.siteHousingArray];
   }
 
   // Populate site info initially with existing site info
   setInitialSite() {
+    let self = this;
     this.site.description =  this.data.site.site_description !== undefined && this.data.site.site_description !== "" ? this.data.site.site_description : null;
     this.site.latitude_dd = this.data.site.latitude_dd !== undefined && this.data.site.latitude_dd !== "" ? this.data.site.latitude_dd : null;
     this.site.longitude_dd = this.data.site.longitude_dd !== undefined && this.data.site.longitude_dd !== "" ? this.data.site.longitude_dd : null;
@@ -156,10 +348,20 @@ export class SiteEditComponent implements OnInit {
     this.site.city = this.data.site.city !== undefined && this.data.site.city !== "" ? this.data.site.city : null;
     this.site.zip = this.data.site.zip !== undefined && this.data.site.zip !== "" ? this.data.site.zip : null;
     this.site.memberName = this.data.memberName !== undefined && this.data.memberName !== "---" && this.data.memberName !== "" ? this.data.memberName : null;
-    this.siteHousingArray = this.data.siteHousing;
+    this.hasLandownerContact = this.data.site.landownercontact_id !== undefined && this.data.site.landownercontact_id !== "---" && this.data.site.landownercontact_id !== "" ? true : null;
+    this.landownerContact = this.data.landowner !== "" && this.data.landowner !== undefined && this.data.landowner !== null ? this.data.landowner : this.landownerContact;
+    this.data.siteHousing.forEach(function(type){
+      self.siteHousingArray.push(type);
+      self.housingTypeArray.push(type.housingType);
+    });
+    this.initSiteFiles = this.data.siteFiles;
+    this.priority = this.data.priority !== undefined && this.data.priority !== null ? this.data.priority : {priority_id: null};
     
     this.perm_housing_installed = this.data.site.is_permanent_housing_installed !== undefined && this.data.site.is_permanent_housing_installed === "Yes" ? "Yes" : "No";
     this.sensorNotAppropriate = this.data.site.sensor_not_appropriate !== undefined && this.sensorNotAppropriate === 1 ? true : false;
+    if(this.sensorNotAppropriate){
+      this.permHousingDisabled = true;
+    }
     if (this.data.site.access_granted !== undefined){
       if(this.data.site.access_granted === "Yes"){
         this.accessGranted = "Yes";
@@ -181,6 +383,7 @@ export class SiteEditComponent implements OnInit {
           if(state.state_abbrev === self.data.site.state){
             self.site.state = state.state_name;
             self.getCountyList(self.site.state);
+            self.siteForm.controls['state'].setValue(self.site.state);
           }
         });
       }
@@ -198,12 +401,485 @@ export class SiteEditComponent implements OnInit {
           });
           if(stateName !== self.site.state){
             self.site.county = null;
+            self.siteForm.controls['county'].setValue(self.site.county);
           }
         }
       })
   }
 
+  addLandownerContact() {
+    this.addLandownerCheck = true;
+  }
+
+  deleteLandowner() {
+    this.addLandownerCheck = false;
+  }
+
+  initLandownerForm() {
+    this.landownerForm = new FormGroup({
+      fname: new FormControl(this.landownerContact.fname, Validators.required),
+      lname: new FormControl(this.landownerContact.lname),
+      title: new FormControl(this.landownerContact.title),
+      address: new FormControl(this.landownerContact.address),
+      city: new FormControl(this.landownerContact.city),
+      state: new FormControl(this.landownerContact.state),
+      zip: new FormControl(this.landownerContact.zip),
+      email: new FormControl(this.landownerContact.email),
+      primaryphone: new FormControl(this.landownerContact.primaryphone),
+      secondaryphone: new FormControl(this.landownerContact.secondaryphone),
+    })
+  }
+
+  useAddressforLO() {
+    this.useSiteAddress = !this.useSiteAddress;
+    if (this.useSiteAddress) {
+      this.landownerContact.address = this.site.address;
+      this.landownerContact.city = this.site.city;
+      this.landownerContact.state = this.site.state;
+      this.landownerContact.zip = this.site.zip;
+      this.landownerForm.controls['address'].setValue(this.landownerContact.address);
+      this.landownerForm.controls['city'].setValue(this.landownerContact.city);
+      this.landownerForm.controls['state'].setValue(this.landownerContact.state);
+      this.landownerForm.controls['zip'].setValue(this.landownerContact.zip);
+    } else {
+      this.landownerContact.address = "";
+      this.landownerContact.city = "";
+      this.landownerContact.state = "";
+      this.landownerContact.zip = "";
+      this.landownerForm.controls['address'].setValue(this.landownerContact.address);
+      this.landownerForm.controls['city'].setValue(this.landownerContact.city);
+      this.landownerForm.controls['state'].setValue(this.landownerContact.state);
+      this.landownerForm.controls['zip'].setValue(this.landownerContact.zip);
+
+    }
+  }
+
+  addSiteFile() {
+    // Reset form
+    this.cancelFile();
+    this.showFileForm = true;
+    this.addFileType = "New";
+  }
+
+  getFileTypeSelection(event) {
+    this.siteFiles.filetype_id = event.value;
+  }
+
+  initSiteForm() {
+    this.siteForm = new FormGroup({
+      site_description: new FormControl(this.site.description, Validators.required),
+      site_notes: new FormControl(this.site.internal_notes),
+      latitude_dd: new FormControl(this.site.latitude_dd),
+      longitude_dd: new FormControl(this.site.longitude_dd),
+      is_permanent_housing_installed: new FormControl({value: this.perm_housing_installed, disabled: this.permHousingDisabled}),
+      access_granted: new FormControl(this.accessGranted),
+      hdatum: new FormControl(this.site.hdatum, Validators.required),
+      hmethod: new FormControl(this.site.hmethod, Validators.required),
+      waterbody: new FormControl(this.site.waterbody, Validators.required),
+      drainage_area_sqmi: new FormControl(this.site.drainage_area),
+      usgs_sid: new FormControl(this.site.usgs_id),
+      noaa_sid: new FormControl(this.site.noaa_id),
+      other_sid: new FormControl(this.site.other_id),
+      safety_notes: new FormControl(this.site.safety_notes),
+      zone: new FormControl(this.site.zone),
+      address: new FormControl(this.site.address),
+      city: new FormControl(this.site.city),
+      state: new FormControl(this.site.state, Validators.required),
+      county: new FormControl(this.site.county, Validators.required),
+      zip: new FormControl(this.site.zip),
+      housingType: new FormControl(this.housingTypeArray),
+      priority_id: new FormControl(this.priority.priority_id),
+      latdeg: new FormControl(this.dms.latdeg),
+      latmin: new FormControl(this.dms.latmin),
+      latsec: new FormControl(this.dms.latsec),
+      londeg: new FormControl(this.dms.londeg),
+      lonmin: new FormControl(this.dms.lonmin),
+      lonsec: new FormControl(this.dms.lonsec),
+      networkType: new FormArray([]),
+      networkName: new FormArray([]),
+      landownercontact_id: new FormControl(),
+    });
+
+    this.setLatLngValidators();
+  }
+
+  setLatLngValidators() {
+    if (this.latLngUnit === "dms"){
+      this.siteForm.controls.latdeg.setValidators([Validators.required, this.checkDDLatDegValue()]);
+      this.siteForm.controls.latmin.setValidators([Validators.required, this.checkDDLatMinValue()]);
+      this.siteForm.controls.latsec.setValidators([Validators.required, this.checkDDLatSecValue()]);
+      this.siteForm.controls.londeg.setValidators([Validators.required, this.checkDDLonDegValue()]);
+      this.siteForm.controls.lonmin.setValidators([Validators.required, this.checkDDLonMinValue()]);
+      this.siteForm.controls.lonsec.setValidators([Validators.required, this.checkDDLonSecValue()]);
+      this.siteForm.controls.latitude_dd.setValidators();
+      this.siteForm.controls.longitude_dd.setValidators();
+    }else{
+      this.siteForm.controls.latitude_dd.setValidators([Validators.required, this.checkLatValue()]);
+      this.siteForm.controls.longitude_dd.setValidators([Validators.required, this.checkLonValue()]);
+      this.siteForm.controls.latdeg.setValidators();
+      this.siteForm.controls.latmin.setValidators();
+      this.siteForm.controls.latsec.setValidators();
+      this.siteForm.controls.londeg.setValidators();
+      this.siteForm.controls.lonmin.setValidators();
+      this.siteForm.controls.lonsec.setValidators();
+    }
+  }
+
+  range = function (x, min, max) {
+    return x < min || x > max;
+  }
+
+  checkNaN = function(x){
+    return isNaN(x);
+  }
+
+  initSiteFileForm() {
+    this.siteFileForm = new FormGroup({
+      File: new FormControl(),
+      file_id: new FormControl(this.siteFiles.file_id),
+      name: new FormControl(this.siteFiles.name),
+      FULLname: new FormControl(this.siteFiles.FULLname, Validators.required),
+      description: new FormControl(this.siteFiles.description, Validators.required),
+      file_date: new FormControl(this.siteFiles.file_date, Validators.required),
+      photo_date: new FormControl(this.siteFiles.photo_date, Validators.required),
+      agency_id: new FormControl(this.siteFiles.agency_id, Validators.required),
+      site_id: new FormControl(this.siteFiles.site_id),
+      filetype_id: new FormControl(this.siteFiles.filetype_id, Validators.required),
+      path: new FormControl(this.siteFiles.path),
+      data_file_id: new FormControl(this.siteFiles.data_file_id),
+      instrument_id: new FormControl(this.siteFiles.instrument_id),
+      last_updated: new FormControl(this.siteFiles.last_updated),
+      last_updated_by: new FormControl(this.siteFiles.last_updated_by),
+      site_description: new FormControl(this.siteFiles.site_description),
+      photo_direction: new FormControl(this.siteFiles.photo_direction),
+      latitude_dd: new FormControl(this.siteFiles.latitude_dd, [this.checkLatValue()]),
+      longitude_dd: new FormControl(this.siteFiles.longitude_dd, [this.checkLonValue()]),
+    })
+  }
+
+  formatDate(event){
+    this.formattedPhotoDate = (event.value.getMonth() + 1) + '/' + event.value.getDate() + '/' + event.value.getFullYear();
+  }
+
+  changeLatLngUnit(event) {
+    this.setLatLngValidators();
+    if (event.value == "decdeg") {
+        this.latLngUnit = "decdeg";
+        //they clicked Dec Deg..
+        if ((this.siteForm.controls.latdeg.value !== undefined && this.siteForm.controls.latmin.value !== undefined && this.siteForm.controls.latsec.value !== undefined) &&
+            (this.siteForm.controls.londeg.value !== undefined && this.siteForm.controls.lonmin.value !== undefined && this.siteForm.controls.lonsec.value !== undefined)) {
+            //convert what's here for each lat and long
+            this.siteForm.controls['latitude_dd'].setValue(this.azimuth(this.siteForm.controls.latdeg.value, this.siteForm.controls.latmin.value, this.siteForm.controls.latsec.value));
+            this.siteForm.controls['longitude_dd'].setValue(this.azimuth(this.siteForm.controls.londeg.value, this.siteForm.controls.lonmin.value, this.siteForm.controls.lonsec.value));
+            this.incorrectDMS = false;
+        } else {
+            //show card telling them to populate all three (DMS) for conversion to work
+            this.incorrectDMS = true;
+        }
+    } else {
+        this.latLngUnit = "dms"
+        //they clicked dms (convert lat/long to dms)
+        if (this.siteForm.controls.latitude_dd.value !== undefined && this.siteForm.controls.longitude_dd.value !== undefined) {
+            var latDMS = (this.deg_to_dms(this.siteForm.controls.latitude_dd.value)).toString();
+            var ladDMSarray = latDMS.split(':');
+            this.siteForm.controls['latdeg'].setValue(ladDMSarray[0]);
+            this.siteForm.controls['latmin'].setValue(ladDMSarray[1]);
+            this.siteForm.controls['latsec'].setValue(ladDMSarray[2]);
+
+            var longDMS = this.deg_to_dms(this.siteForm.controls.longitude_dd.value);
+            var longDMSarray = longDMS.split(':');
+            this.siteForm.controls['londeg'].setValue(-(longDMSarray[0]));
+            this.siteForm.controls['lonmin'].setValue(longDMSarray[1]);
+            this.siteForm.controls['lonsec'].setValue(longDMSarray[2]);
+        }
+    }
+  }
+
+  // Validate lat/lngs
+  checkLatValue() {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const incorrect = this.range(control.value, 0, 73) || this.checkNaN(control.value);
+      return incorrect ? {incorrectValue: {value: control.value}} : null;
+    };
+  }
+
+  checkLonValue() {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const incorrect = this.range(control.value, -175, -60) || this.checkNaN(control.value);
+      return incorrect ? {incorrectValue: {value: control.value}} : null;
+    };
+  }
+
+  checkDDLonDegValue() {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const incorrect = this.range(control.value, -175, -60) || this.checkNaN(control.value) || control.value === undefined;
+      return incorrect ? {incorrectValue: {value: control.value}} : null;
+    };
+  }
+
+  checkDDLonMinValue() {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const incorrect = this.checkNaN(control.value) || control.value === undefined;
+      return incorrect ? {incorrectValue: {value: control.value}} : null;
+    };
+  }
+
+  checkDDLonSecValue() {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const incorrect = this.checkNaN(control.value) || control.value === undefined;
+      return incorrect ? {incorrectValue: {value: control.value}} : null;
+    };
+  }
+
+  checkDDLatDegValue() {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const incorrect = this.range(control.value, 0, 73) || this.checkNaN(control.value) || control.value === undefined;
+      return incorrect ? {incorrectValue: {value: control.value}} : null;
+    };
+  }
+
+  checkDDLatMinValue() {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const incorrect = this.checkNaN(control.value) || control.value === undefined;
+      return incorrect ? {incorrectValue: {value: control.value}} : null;
+    };
+  }
+
+  checkDDLatSecValue() {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const incorrect = this.checkNaN(control.value) || control.value === undefined;
+      return incorrect ? {incorrectValue: {value: control.value}} : null;
+    };
+  }
+
+  //convert deg min sec to dec degrees
+  azimuth = function (deg, min, sec) {
+    var azi = 0;
+    if (deg < 0) {
+        azi = -1.0 * deg + 1.0 * min / 60.0 + 1.0 * sec / 3600.0;
+        return (-1.0 * azi).toFixed(5);
+    }
+    else {
+        azi = 1.0 * deg + 1.0 * min / 60.0 + 1.0 * sec / 3600.0;
+        return (azi).toFixed(5);
+    }
+  }
+
+  //convert dec degrees to dms
+  deg_to_dms = function (deg) {
+    if (deg < 0) {
+        deg = deg.toString();
+
+        //longitude, remove the - sign
+        deg = deg.substring(1);
+    }
+    var d = Math.floor(deg);
+    var minfloat = (deg - d) * 60;
+    var m = Math.floor(minfloat);
+    var s = ((minfloat - m) * 60).toFixed(3);
+
+    return ("" + d + ":" + m + ":" + s);
+  }
+
+  updateAgencyForCaption(event) {
+    let self = this;
+    if (this.siteFileForm.controls['filetype_id'].value == 1)
+        this.agencyNameForCap = this.agencies.filter(function (a) { return a.agency_id == self.siteFileForm.controls['agency_id'].value; })[0].agency_name;
+  }
+
+  sensorAppropriateChanged(event){
+    if(event.checked){
+      this.perm_housing_installed = "No";
+      this.siteForm.controls['is_permanent_housing_installed'].setValue(this.perm_housing_installed);
+      this.siteForm.controls['is_permanent_housing_installed'].disable();
+
+    }else{
+      this.siteForm.controls['is_permanent_housing_installed'].enable();
+    }
+  }
+
+  showFileEdit(row) {
+    // Reset form
+    this.cancelFile();
+    this.setInitFileEditForm(row);
+    this.showFileForm = true;
+    this.siteFiles.file_id = row.file_id;
+    this.siteFiles.filetype_id = row.filetype_id;
+    this.addFileType = "Existing";
+
+    this.getFile();
+  }
+
+  setInitFileEditForm(data) {
+    this.siteFileForm.controls['file_id'].setValue(data.file_id);
+    this.siteFileForm.controls['name'].setValue(data.name);
+    this.siteFileForm.controls['FULLname'].setValue(data.FULLname);
+    this.siteFileForm.controls['description'].setValue(data.description);
+    this.siteFileForm.controls['file_date'].setValue(data.file_date);
+    this.siteFileForm.controls['photo_date'].setValue(data.photo_date);
+    this.siteFileForm.controls['agency_id'].setValue(data.agency_id);
+    this.siteFileForm.controls['site_id'].setValue(data.site_id);
+    this.siteFileForm.controls['filetype_id'].setValue(data.filetype_id);
+    this.siteFileForm.controls['path'].setValue(data.path);
+    this.siteFileForm.controls['instrument_id'].setValue(data.instrument_id);
+    this.siteFileForm.controls['last_updated'].setValue(data.last_updated);
+    this.siteFileForm.controls['last_updated_by'].setValue(data.last_updated_by);
+    this.siteFileForm.controls['site_description'].setValue(data.site_description);
+    this.siteFileForm.controls['photo_direction'].setValue(data.photo_direction);
+    this.siteFileForm.controls['latitude_dd'].setValue(data.latitude_dd);
+    this.siteFileForm.controls['longitude_dd'].setValue(data.longitude_dd);
+  }
+
+  getFile() {
+    if(this.siteFiles.file_id !== null && this.siteFiles.file_id !== undefined){
+      this.siteService.getFileItem(this.siteFiles.file_id).subscribe((results) => {
+        console.log(results)
+        if(results.FileName !== undefined) {
+          this.fileItemExists = true;
+          this.fileSource = APP_SETTINGS.API_ROOT + 'Files/' + this.siteFiles.file_id + '/item';
+        }else{
+          this.fileItemExists = false;
+        }
+      });
+    }else{
+      this.fileItemExists = false;
+    }
+  }
+
+  saveFileUpload(event) {
+    console.log(event)
+  }
+
+  cancelFile() {
+    // Reset file inputs
+    this.changeDetector.detectChanges();
+    console.log(this.upload)
+    if(this.upload !== undefined){
+      this.upload.nativeElement.value = '';
+    }
+
+    this.showFileForm = false;
+
+    this.siteFileForm.reset();
+
+    // this.existingFile = {
+    //   file_id: null,
+    //   filetype_id: null,
+    // }
+
+    this.siteFiles = {
+      file_id: null,
+      name: null,
+      FULLname: null,
+      description: null,
+      file_date: null,
+      photo_date: null,
+      agency_id: null,
+      site_id: null,
+      filetype_id: null,
+      path: null,
+      data_file_id: null,
+      instrument_id: null,
+      last_updated: null,
+      last_updated_by: null,
+      site_description: null,
+      photo_direction: null,
+      latitude_dd: null,
+      longitude_dd: null,
+    };
+  }
+
   submitSiteForm(){
-    console.log("submitted!");
+    this.siteForm.markAllAsTouched();
+    if(this.siteForm.valid){
+      this.valid = true;
+      // Post landowner if added
+      if(this.addLandownerCheck){
+        if(this.landownerForm.valid){
+          this.landownerValid = true;
+          console.log(this.landownerForm.value)
+          this.siteEditService.putLandowner(this.landownerForm.value).subscribe((response) => {
+            console.log(response);
+            this.putSite();
+            this.dialogRef.close();
+          })
+        }else{
+          this.landownerValid = false;
+          this.putSite();
+          alert("Error creating landowner contact.")
+          this.dialogRef.close();
+        }
+      }
+      else{
+        this.putSite();
+        this.dialogRef.close();
+      }
+      // Close dialog
+    }else{
+      this.valid = false;
+      alert("Some required site fields are missing or incorrect.  Please fix these fields before submitting.")
+    }
+
+    // date updated
+  }
+
+  putSite() {
+    // Convert dms to dd
+    if(this.latLngUnit === "dms"){
+      this.siteForm.controls['latitude_dd'].setValue(this.azimuth(this.siteForm.controls.latdeg.value, this.siteForm.controls.latmin.value, this.siteForm.controls.latsec.value));
+      this.siteForm.controls['longitude_dd'].setValue(this.azimuth(this.siteForm.controls.londeg.value, this.siteForm.controls.lonmin.value, this.siteForm.controls.lonsec.value));
+    }
+    // Copy form value object and delete extra fields
+    let siteSubmission = JSON.parse(JSON.stringify(this.siteForm.value));
+    delete siteSubmission.latdeg; delete siteSubmission.latmin; delete siteSubmission.latsec; delete siteSubmission.londeg; delete siteSubmission.lonmin; delete siteSubmission.lonsec;
+    
+    console.log(siteSubmission);
+    console.log(this.siteForm.value);
+
+    // this.siteEditService.submitForm(this.siteForm.value)
+    //   .subscribe(
+    //       (data) => {
+    //           console.log('Form submitted successfully'); 
+    //           console.log(data)                          
+    //       },
+    //       (error: HttpErrorResponse) => {
+    //           console.log(error);
+    //       }
+    //   );
+
+    // create list of housing types, network names and network types to remove
+    // Delete housing info
+    // Delete netowrk type info
+    // delete network names
+    // Insert housing info
+    // Insert Network type and network name
+    // Insert hdatum and hcollection method info
+    // Insert priority info
+  }
+
+  saveFile() {
+    this.siteFileForm.markAllAsTouched();
+    if(this.siteFileForm.valid){
+      this.fileValid = true;
+      console.log(this.siteFileForm.value)
+    }else{
+      this.fileValid = false;
+      alert("Some required site file fields are missing or incorrect.  Please fix these fields before submitting.")
+    }
+  }
+
+  deleteFile() {
+
+  }
+
+  createFile() {
+    this.siteFileForm.markAllAsTouched();
+    if(this.siteFileForm.valid){
+      this.fileValid = true;
+      console.log(this.siteFileForm.value)
+    }else{
+      this.fileValid = false;
+      alert("Some required site file fields are missing or incorrect.  Please fix these fields before submitting.")
+    }
   }
 }


### PR DESCRIPTION
I didn't add a confirm dialog after the user clicks Save.  I wasn't sure if it was really necessary since we already have it in a dialog. There is a confirm before the user deletes a file though.  I make another ticket if we do want to add another confirm in.

There are a few more issues I'll make separate tickets for: replacing validation alerts with error/success snackbars, autopopulating the source info (name and organization), and adding a mask for zip code and phone number fields