### PR TITLE
237 - map result table updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 -   Edit ability for Peaks
 -   View details for Peaks
+-   Adds view sensor button to results table which opens dialog listing sensors; includes button to site page
+-   Makes siteid a link to site page
 
 ### Changed
 

--- a/src/app/filter-results/filter-results.component.html
+++ b/src/app/filter-results/filter-results.component.html
@@ -19,7 +19,7 @@
                         Site ID
                     </th>
                     <td mat-cell *matCellDef="let element">
-                        {{ element.site_id }}
+                        <a class="site-link" role="button" tabindex="0" (click)="routeToSite(element.site_id)">{{ element.site_id }}</a>
                     </td>
                 </ng-container>
 
@@ -89,7 +89,7 @@
                     </td>
                 </ng-container>
 
-                <!-- waterbody Column -->
+                <!-- permanent housing Column -->
                 <ng-container matColumnDef="permHouse">
                     <th mat-header-cell
                         *matHeaderCellDef
@@ -102,12 +102,22 @@
                     </td>
                 </ng-container>
 
+                <!-- Button Column -->
+                <ng-container matColumnDef="button">
+                    <th mat-header-cell *matHeaderCellDef>
+                    </th>
+                    <td mat-cell *matCellDef="let row">
+                        <button mat-stroked-button class="view-details-btn" (click)="openDetailsDialog(row)"
+                            aria-label="View Sensors"><mat-icon>search</mat-icon> View Sensors
+                        </button>
+                    </td>
+                </ng-container>    
+
                 <tr mat-header-row
                     *matHeaderRowDef="displayedColumns"
                 ></tr>
                 <tr mat-row
                     *matRowDef="let row; columns: displayedColumns"
-                    (click)="openDetailsDialog(row)"
                     class="results-row"
                 ></tr>
             </table>

--- a/src/app/filter-results/filter-results.component.scss
+++ b/src/app/filter-results/filter-results.component.scss
@@ -6,10 +6,6 @@ table {
     overflow-x: auto;
 }
 
-.results-row {
-    cursor: pointer;
-}
-
 .mat-column-siteId{
     padding: 10px;
     border-right: 1px solid #e0e0e0;
@@ -70,6 +66,13 @@ table {
 
 .mat-column-permHouse{
     padding: 10px;
+    border-right: 1px solid #e0e0e0;
+    vertical-align: top;
+    align-self: stretch;
+}
+
+.mat-column-button{
+    padding: 10px;
     vertical-align: top;
     align-self: stretch;
 }
@@ -85,4 +88,15 @@ table {
 
 .mat-cell, .mat-header-cell, .mat-footer-cell {
     overflow: auto;
+}
+
+.view-details-btn {
+    margin: 5px 5px;
+    border: 1px solid #404040;
+}
+
+.site-link {
+    text-decoration: underline;
+    color: blue;
+    cursor: pointer;
 }

--- a/src/app/filter-results/filter-results.component.spec.ts
+++ b/src/app/filter-results/filter-results.component.spec.ts
@@ -18,6 +18,7 @@ import { Site } from '@app/interfaces/site';
 import { MatDialogRef } from '@angular/material/dialog';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ResultDetailsComponent } from '../result-details/result-details.component';
+import { RouterTestingModule } from '@angular/router/testing';
 export const mockSitesList: Site[] = APP_UTILITIES.SITES_DUMMY_DATA_LIST;
 
 describe('FilterResultsComponent', () => {
@@ -41,6 +42,7 @@ describe('FilterResultsComponent', () => {
                 MatDialogModule,
                 MatInputModule,
                 MatSortModule,
+                RouterTestingModule,
             ],
             providers: [
                 SiteService,

--- a/src/app/filter-results/filter-results.component.ts
+++ b/src/app/filter-results/filter-results.component.ts
@@ -7,6 +7,7 @@ import { FiltersService } from '@services/filters.service';
 import { MatDialog } from '@angular/material/dialog';
 import { BehaviorSubject, Subscription } from 'rxjs/Rx';
 import { ResultDetailsComponent } from '../result-details/result-details.component';
+import {Router} from '@angular/router';
 
 @Component({
     selector: 'app-filter-results',
@@ -35,11 +36,13 @@ export class FilterResultsComponent implements OnInit {
         'longitude',
         'waterbody',
         'permHouse',
+        'button',
     ];
 
     constructor(
         private filtersService: FiltersService,
-        public dialog: MatDialog
+        public dialog: MatDialog,
+        private router: Router,
     ) {
         this.filtersService.selectedSites.subscribe(
             (currentSites) => (this.currentSites = currentSites)
@@ -85,6 +88,10 @@ export class FilterResultsComponent implements OnInit {
         // setting sort and paging
         this.dataSource.sort = this.sort;
         this.dataSource.paginator = this.paginator;
+    }
+
+    routeToSite(siteID){
+        this.router.navigateByUrl('/Site/' + siteID + '/SiteDashboard');
     }
 
     // fired when user clicks a sortable header

--- a/src/app/result-details/result-details.component.html
+++ b/src/app/result-details/result-details.component.html
@@ -104,7 +104,8 @@
 </mat-dialog-content>
 <mat-dialog-actions align="end">
     <div class="detail-section-buttons centered">
-        <button mat-button mat-dialog-close cdkFocusInitial aria-label="Close">Close</button>
+        <button mat-button class="primary save-btn" mat-dialog-close cdkFocusInitial (click)="routeToSite()" aria-label="View Site">View Site</button>
+        <button mat-stroked-button class="close-btn" mat-dialog-close cdkFocusInitial aria-label="Close">Close</button>
         <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
     </div>
 </mat-dialog-actions>

--- a/src/app/result-details/result-details.component.scss
+++ b/src/app/result-details/result-details.component.scss
@@ -81,3 +81,12 @@ table {
     width: 100%;
     overflow-y: hidden;
 }
+
+.save-btn {
+    color: #F4F4F4;
+}
+
+.close-btn {
+    margin: 5px 5px;
+    border: 1px solid #404040;
+}

--- a/src/app/result-details/result-details.component.spec.ts
+++ b/src/app/result-details/result-details.component.spec.ts
@@ -21,6 +21,7 @@ import { APP_SETTINGS } from '@app/app.settings';
 import { of } from 'rxjs';
 import { Event } from '@interfaces/event';
 import { Sitefullsensors } from '@interfaces/sitefullsensors';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('ResultDetailsComponent', () => {
     let component: ResultDetailsComponent;
@@ -43,6 +44,7 @@ describe('ResultDetailsComponent', () => {
                 MatSortModule,
                 MatAutocompleteModule,
                 MatAutocompleteModule,
+                RouterTestingModule,
             ],
             providers: [
                 SensorService,

--- a/src/app/result-details/result-details.component.ts
+++ b/src/app/result-details/result-details.component.ts
@@ -14,6 +14,7 @@ import { MatSort } from '@angular/material/sort';
 import { Sort } from '@angular/material/sort';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { APP_UTILITIES } from '@app/app.utilities';
+import { Router } from '@angular/router';
 
 @Component({
     selector: 'app-result-details',
@@ -41,7 +42,8 @@ export class ResultDetailsComponent implements OnInit {
         @Inject(MAT_DIALOG_DATA) public data: any,
         private sensorService: SensorService,
         private eventService: EventService,
-        private changeDetectorRefs: ChangeDetectorRef
+        private changeDetectorRefs: ChangeDetectorRef,
+        private router: Router,
     ) {}
 
     ngOnInit(): void {
@@ -66,6 +68,10 @@ export class ResultDetailsComponent implements OnInit {
                 this.siteSensors = results;
                 this.getEvents();
             });
+    }
+
+    routeToSite() { 
+        this.router.navigateByUrl('/Site/' + this.data['site_id'] + '/SiteDashboard');
     }
 
     /* istanbul ignore next */


### PR DESCRIPTION
I ended up not adding the sensor count for each site to the View Sensor button because we would need to loop through all filtered sites and get the sensor count.  This was fine when a small number of sites were returned but slowed things down with filters returning more results (e.g. filtering by Louisiana returns > 1200 results).