### PR TITLE
345 - add ability to deploy a sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  -  Added ability to delete HWMs
  -  Ability to create Reference Datums
  -  Added ability to delete reference datums
+ -  Added ability to deploy a sensor
  
 ### Changed
 
@@ -24,7 +25,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  
  ### Fixed
  
- -
+ -  Time reset in sensor edit modal when Cancel Edits is clicked
 
 ## [v0.7.0](https://github.com/USGS-WiM/stnweb2/releases/tag/v0.7.0) - 2022-01-17
 

--- a/src/app/hwm-edit/hwm-edit.component.html
+++ b/src/app/hwm-edit/hwm-edit.component.html
@@ -3,7 +3,7 @@
     <button class="close-button" mat-button mat-dialog-close aria-label="Exit"><mat-icon>close</mat-icon></button>
 </h2>
 <h2 *ngIf="editOrCreate === 'Create'" mat-dialog-title>
-    Create new HWM
+    Create HWM
     <button class="close-button" mat-button mat-dialog-close aria-label="Exit"><mat-icon>close</mat-icon></button>
 </h2>
 

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -781,6 +781,7 @@ export class MapComponent implements OnInit {
         return hasFilters;
     }
 
+    /* istanbul ignore next */
     jumpToResult() {
         let self = this;
         // Open results panel
@@ -1586,6 +1587,7 @@ export class MapComponent implements OnInit {
         })
     }
 
+    /* istanbul ignore next */
     addRouterLink(e){
         let data = e.layer.data;
         this.siteID = data.id;

--- a/src/app/ref-datum-edit/ref-datum-edit.component.html
+++ b/src/app/ref-datum-edit/ref-datum-edit.component.html
@@ -3,7 +3,7 @@
     <button class="close-button" mat-button [mat-dialog-close]="returnData" aria-label="Exit"><mat-icon>close</mat-icon></button>
 </h2>
 <h2 mat-dialog-title *ngIf="editOrCreate === 'Create'">
-    Create new Reference Datum
+    Create Reference Datum
     <button class="close-button" mat-button [mat-dialog-close]="returnData" aria-label="Exit"><mat-icon>close</mat-icon></button>
 </h2>
 <div [hidden]="!loading" class="loading">

--- a/src/app/ref-datum-edit/ref-datum-edit.component.ts
+++ b/src/app/ref-datum-edit/ref-datum-edit.component.ts
@@ -321,6 +321,7 @@ export class RefDatumEditComponent implements OnInit {
     };
   }
 
+  /* istanbul ignore next */
   checkDDLonDegValue() {
     return (control: AbstractControl): ValidationErrors | null => {
       const incorrect = this.range(control.value, -175, -60) || this.checkNaN(control.value) || control.value === undefined;
@@ -328,6 +329,7 @@ export class RefDatumEditComponent implements OnInit {
     };
   }
 
+  /* istanbul ignore next */
   checkDDLonMinValue() {
     return (control: AbstractControl): ValidationErrors | null => {
       const incorrect = this.checkNaN(control.value) || control.value === undefined;
@@ -335,6 +337,7 @@ export class RefDatumEditComponent implements OnInit {
     };
   }
 
+  /* istanbul ignore next */
   checkDDLonSecValue() {
     return (control: AbstractControl): ValidationErrors | null => {
       const incorrect = this.checkNaN(control.value) || control.value === undefined;
@@ -342,6 +345,7 @@ export class RefDatumEditComponent implements OnInit {
     };
   }
 
+  /* istanbul ignore next */
   checkDDLatDegValue() {
     return (control: AbstractControl): ValidationErrors | null => {
       const incorrect = this.range(control.value, 0, 73) || this.checkNaN(control.value) || control.value === undefined;
@@ -349,6 +353,7 @@ export class RefDatumEditComponent implements OnInit {
     };
   }
 
+  /* istanbul ignore next */
   checkDDLatMinValue() {
     return (control: AbstractControl): ValidationErrors | null => {
       const incorrect = this.checkNaN(control.value) || control.value === undefined;
@@ -356,6 +361,7 @@ export class RefDatumEditComponent implements OnInit {
     };
   }
 
+  /* istanbul ignore next */
   checkDDLatSecValue() {
     return (control: AbstractControl): ValidationErrors | null => {
       const incorrect = this.checkNaN(control.value) || control.value === undefined;

--- a/src/app/result-details/result-details.component.ts
+++ b/src/app/result-details/result-details.component.ts
@@ -194,6 +194,7 @@ export class ResultDetailsComponent implements OnInit {
         // Need to update the data source to update the table rows
         this.sensorDataSource.data = this.sortedData;
     }
+    /* istanbul ignore next */
     initCompare(a: string, b: string) {
         if(a === "Deployed"){
             a = "1";

--- a/src/app/sensor-edit/sensor-edit.component.html
+++ b/src/app/sensor-edit/sensor-edit.component.html
@@ -295,7 +295,7 @@
                 </mat-radio-group>
                 <mat-form-field appearance="fill">
                     <mat-label>Deployment Type</mat-label>
-                    <mat-select aria-label="Deployment Type" required formControlName="deployment_type_id">
+                    <mat-select aria-label="Deployment Type" formControlName="deployment_type_id">
                         <mat-option *ngFor="let type of deploymentTypes" [value]="type.deployment_type_id">
                         {{type.method}}
                         </mat-option>
@@ -335,7 +335,8 @@
                                         <mat-datepicker-toggle matSuffix [for]="deployDatePicker"></mat-datepicker-toggle>
                                         <mat-datepicker [value]="instrument.time_stamp" #deployDatePicker></mat-datepicker>
                                     </mat-form-field>
-                                    <input class="date-input" formControlName="hour" type="number" aria-label="Deploy Hour" [value]="instrument.hour" required placeholder="00"> : 
+                                    <input class="date-input" formControlName="hour" type="number" aria-label="Deploy Hour" [value]="instrument.hour" required placeholder="00">
+                                    <span class="date-span"> : </span>
                                     <input class="date-input" formControlName="minute" type="number" aria-label="Deploy Minute" [value]="instrument.minute" required placeholder="00">
                                     <button mat-stroked-button class="date-input date-button secondary" type="button" (click)="changeTime(instrument)" [value]="instrument.ampm">{{instrument.ampm}}</button>
                                 </div>
@@ -350,7 +351,7 @@
                                     aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
                                 </mat-form-field>
                                 <div>
-                                    <label class="form-header">Preview time in UTC: </label> {{instrument.utc_preview}} GMT
+                                    <label class="form-header">Preview time in UTC: </label> {{instrument.utc_preview}}
                                 </div>
                                 <mat-form-field appearance="fill">
                                     <mat-label for="description">Note</mat-label>
@@ -414,7 +415,8 @@
                                         <mat-datepicker-toggle matSuffix [for]="deployDatePicker"></mat-datepicker-toggle>
                                         <mat-datepicker [value]="instrument.time_stamp" #deployDatePicker></mat-datepicker>
                                     </mat-form-field>
-                                    <input class="date-input" formControlName="hour" aria-label="Deploy Hour" type="number" [value]="instrument.hour" required placeholder="00"> : 
+                                    <input class="date-input" formControlName="hour" aria-label="Deploy Hour" type="number" [value]="instrument.hour" required placeholder="00"> 
+                                    <span class="date-span"> : </span>
                                     <input class="date-input" formControlName="minute" aria-label="Deploy Minute" type="number" [value]="instrument.minute" required placeholder="00">
                                     <button mat-stroked-button class="date-input date-button" type="button" (click)="changeTime(instrument)" [value]="instrument.ampm">{{instrument.ampm}}</button>
                                 </div>
@@ -429,7 +431,7 @@
                                     aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
                                 </mat-form-field>
                                 <div>
-                                    <label class="form-header">Preview time in UTC: </label> {{instrument.utc_preview}} GMT
+                                    <label class="form-header">Preview time in UTC: </label> {{instrument.utc_preview}}
                                 </div>
                             </div>
                         </div>
@@ -679,7 +681,8 @@
                                         <mat-datepicker-toggle matSuffix [for]="deployDatePicker"></mat-datepicker-toggle>
                                         <mat-datepicker [value]="instrument.time_stamp" #deployDatePicker></mat-datepicker>
                                     </mat-form-field>
-                                    <input class="date-input" formControlName="hour" aria-label="Deploy Hour" type="number" [value]="instrument.hour" required placeholder="00"> : 
+                                    <input class="date-input" formControlName="hour" aria-label="Deploy Hour" type="number" [value]="instrument.hour" required placeholder="00">
+                                    <span class="date-span"> : </span>
                                     <input class="date-input" formControlName="minute" aria-label="Deploy Minute" type="number" [value]="instrument.minute" required placeholder="00">
                                     <button mat-stroked-button class="date-input date-button" type="button" (click)="changeTime(instrument)" [value]="instrument.ampm">{{instrument.ampm}}</button>
                                 </div>
@@ -694,7 +697,7 @@
                                     aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
                                 </mat-form-field>
                                 <div>
-                                    <label class="form-header">Preview time in UTC: </label> {{instrument.utc_preview}} GMT
+                                    <label class="form-header">Preview time in UTC: </label> {{instrument.utc_preview}}
                                 </div>
                             </div>
                         </div>

--- a/src/app/sensor-edit/sensor-edit.component.html
+++ b/src/app/sensor-edit/sensor-edit.component.html
@@ -1,5 +1,9 @@
-<h2 mat-dialog-title>
+<h2 *ngIf="editOrCreate === 'Edit'" mat-dialog-title>
     Edit Sensor
+    <button class="close-button" mat-button [mat-dialog-close]="returnData" aria-label="Exit"><mat-icon>close</mat-icon></button>
+</h2>
+<h2 *ngIf="editOrCreate === 'Create'" mat-dialog-title>
+    Deploy Sensor
     <button class="close-button" mat-button [mat-dialog-close]="returnData" aria-label="Exit"><mat-icon>close</mat-icon></button>
 </h2>
 <div [hidden]="!loading" class="loading">
@@ -9,7 +13,7 @@
     <mat-dialog-content>
         <mat-accordion multi="true">
             <mat-expansion-panel hideToggle [expanded]="deployedExpanded" (opened)="deployedExpanded = true" (closed)="deployedExpanded = false">
-                <mat-expansion-panel-header>
+                <mat-expansion-panel-header *ngIf="editOrCreate === 'Edit'">
                     <mat-panel-title *ngIf="!deployedExpanded" style="color: grey; font-weight: 500">
                         Deployed Sensor Information
                     </mat-panel-title>
@@ -17,10 +21,10 @@
                         Deployed Sensor Information
                     </mat-panel-title>
                 </mat-expansion-panel-header>
-                <div *ngIf="role === 2 || role === 3">
+                <div *ngIf="(editOrCreate === 'Edit' && (role === 2 || role === 3)) || editOrCreate === 'Create'">
                     <label class="form-header">Event: </label> {{this.sensor.eventName}}
                 </div>
-                <div *ngIf="role === 1">
+                <div *ngIf="role === 1 && editOrCreate === 'Edit'">
                     <mat-form-field appearance="fill">
                         <mat-label>Event</mat-label>
                         <mat-select required aria-label="Event" formControlName="event_id">
@@ -67,204 +71,231 @@
                     </mat-select>
                 </mat-form-field>
                 <mat-divider></mat-divider>
-                <div class="tapedown-header">
-                    <label class="form-header">Tapedowns: </label>
-                </div>
-                <div class="tapedowns" [hidden]="!opsPresent">
-                        <mat-form-field appearance="fill">
-                            <mat-label>Reference Datums</mat-label>
-                                    <mat-select aria-label="Reference Datums" formControlName="deployedRefMarks" (selectionChange)="changeTableValue($event.value, 'Deployed')" multiple>
-                                        <mat-option *ngFor="let refmark of data.siteRefMarks" [value]="refmark.name">
-                                        {{refmark.name}}
-                                        </mat-option>
-                                    </mat-select>
-                                <mat-icon matSuffix class="info-icon" matTooltip="These elevations and tapedown data are used for both field activities and final products. Please pay attention to how your data is entered." 
-                                aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
-                        </mat-form-field>
-                </div>
-                <div class="tapedowns" [hidden]="opsPresent">
-                    <label>
-                        No Datum Locations have been added to this site yet to use for a tape down
-                    </label>
-                </div>
-                <div class="tableContainer">
-                    <table [hidden]="!form.controls.deployedTapedowns.length > 0"
-                        #deployedTable
-                        mat-table
-                        id="tapedownsTable"
-                        [dataSource]="deployedTapedowns"
-                        formArrayName="deployedTapedowns"
-                        class="mat-elevation-z5"
-                        matSort
-                    >
+                <!-- Edit Deployed tapedowns -->
+                <mat-expansion-panel hideToggle [expanded]="tapedownsExpanded" (opened)="tapedownsExpanded = true" (closed)="tapedownsExpanded = false">
+                    <mat-expansion-panel-header *ngIf="editOrCreate === 'Create'">
+                        <mat-panel-title *ngIf="!tapedownsExpanded" style="color: grey; font-weight: 500">
+                            Tapedown Information
+                        </mat-panel-title>
+                        <mat-panel-title *ngIf="tapedownsExpanded" style="color: #FFF; font-weight: 550">
+                            Tapedown Information
+                        </mat-panel-title>
+                        <mat-icon matSuffix class="info-icon-white" matTooltip="These elevations and tapedown data are used for both field activities and final products. Please pay attention to how your data is entered." 
+                        aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
+                    </mat-expansion-panel-header>
+                    <mat-form-field appearance="fill" *ngIf="editOrCreate === 'Create'">
+                        <mat-label>Reference Datums</mat-label>
+                        <mat-select aria-label="Reference Datums" formControlName="deployedRefMarks" (selectionChange)="changeTableValue($event.value, 'Deployed')" multiple>
+                            <mat-option *ngFor="let refmark of data.siteRefMarks" [value]="refmark.name">
+                            {{refmark.name}}
+                            </mat-option>
+                        </mat-select>
+                    </mat-form-field>
+                    <div class="tapedown-header" *ngIf="editOrCreate === 'Edit'">
+                        <label class="form-header">Tapedowns: </label>
+                    </div>
+                    <div class="tapedowns" [hidden]="!opsPresent">
+                            <mat-form-field appearance="fill">
+                                <mat-label>Reference Datums</mat-label>
+                                        <mat-select aria-label="Reference Datums" formControlName="deployedRefMarks" (selectionChange)="changeTableValue($event.value, 'Deployed')" multiple>
+                                            <mat-option *ngFor="let refmark of data.siteRefMarks" [value]="refmark.name">
+                                            {{refmark.name}}
+                                            </mat-option>
+                                        </mat-select>
+                                    <mat-icon matSuffix class="info-icon" matTooltip="These elevations and tapedown data are used for both field activities and final products. Please pay attention to how your data is entered." 
+                                    aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
+                            </mat-form-field>
+                    </div>
+                    <div class="tapedowns" [hidden]="opsPresent || editOrCreate !== 'Edit'">
+                        <label>
+                            No Datum Locations have been added to this site yet to use for a tape down
+                        </label>
+                    </div>
+                    <div class="tableContainer">
+                        <table [hidden]="!form.controls.deployedTapedowns.length > 0"
+                            #deployedTable
+                            mat-table
+                            id="tapedownsTable"
+                            [dataSource]="deployedTapedowns"
+                            formArrayName="deployedTapedowns"
+                            class="mat-elevation-z5"
+                            matSort
+                        >
 
-                        <!-- Reference Datum name column -->
-                        <ng-container matColumnDef="ReferenceDatum">
-                            <th mat-header-cell *matHeaderCellDef>Reference Datum</th>
-                            <td mat-cell *matCellDef="let tapedown; let i = index" [formGroupName]="i">
-                                <mat-form-field>
-                                    <input matInput formControlName="op_name" [value]="tapedown.op_name" class="disabled"/>
-                                </mat-form-field>
-                            </td>
-                        </ng-container>
-    
-                        <!-- Elevation column -->
-                        <ng-container matColumnDef="Elevation">
-                            <th mat-header-cell *matHeaderCellDef>Elevation</th>
-                            <td mat-cell *matCellDef="let tapedown; let i = index" [formGroupName]="i">
-                                <mat-form-field>
-                                    <div class="inline-fields">
-                                        <div *ngIf="tapedown.elevation !== undefined">
-                                            <input matInput formControlName="elevation" [value]="tapedown.elevation" class="disabled"/>
+                            <!-- Reference Datum name column -->
+                            <ng-container matColumnDef="ReferenceDatum">
+                                <th mat-header-cell *matHeaderCellDef>Reference Datum</th>
+                                <td mat-cell *matCellDef="let tapedown; let i = index" [formGroupName]="i">
+                                    <mat-form-field>
+                                        <input matInput formControlName="op_name" [value]="tapedown.op_name" class="disabled"/>
+                                    </mat-form-field>
+                                </td>
+                            </ng-container>
+        
+                            <!-- Elevation column -->
+                            <ng-container matColumnDef="Elevation">
+                                <th mat-header-cell *matHeaderCellDef>Elevation</th>
+                                <td mat-cell *matCellDef="let tapedown; let i = index" [formGroupName]="i">
+                                    <mat-form-field>
+                                        <div class="inline-fields">
+                                            <div *ngIf="tapedown.elevation !== undefined && tapedown.elevation !== null">
+                                                <input matInput formControlName="elevation" [value]="tapedown.elevation" class="disabled"/>
+                                            </div>
+                                            <input matInput formControlName="vdatum" [value]="tapedown.vdatum" class="disabled"/>
                                         </div>
-                                        <input matInput formControlName="vdatum" [value]="tapedown.vdatum" class="disabled"/>
+                                    </mat-form-field>
+                                    <!-- Elevation Validator -->
+                                    <div *ngIf="form.controls.deployedTapedowns.controls[i].controls.elevation.invalid && (form.controls.deployedTapedowns.controls[i].controls.elevation.dirty || form.controls.deployedTapedowns.controls[i].controls.elevation.touched)"
+                                        class="alert alert-danger">
+                                        <div *ngIf="form.controls.deployedTapedowns.controls[i].controls.elevation.errors?.['incorrectValue']">
+                                            Elevation must be a numeric value.
+                                        </div>
                                     </div>
-                                </mat-form-field>
-                                <!-- Elevation Validator -->
-                                <div *ngIf="form.controls.deployedTapedowns.controls[i].controls.elevation.invalid && (form.controls.deployedTapedowns.controls[i].controls.elevation.dirty || form.controls.deployedTapedowns.controls[i].controls.elevation.touched)"
-                                    class="alert alert-danger">
-                                    <div *ngIf="form.controls.deployedTapedowns.controls[i].controls.elevation.errors?.['incorrectValue']">
-                                        Elevation must be a numeric value.
-                                    </div>
-                                </div>
-                            </td>
-                        </ng-container>
+                                </td>
+                            </ng-container>
 
-                        <!-- Offset correction column -->
-                        <ng-container matColumnDef="OffsetCorrection">
-                            <th mat-header-cell *matHeaderCellDef>Offset Correction</th>
-                            <td mat-cell *matCellDef="let tapedown; let i = index" [formGroupName]="i">
-                                <mat-form-field appearance="fill">
-                                    <input matInput type="number" formControlName="offset_correction" [value]="tapedown.offset_correction"/>
-                                    <mat-icon matSuffix class="info-icon" matTooltip="From the datum location to the sensor orifice."
-                                    aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
-                                </mat-form-field>
-                                <!-- Offset Correction Validator -->
-                                <div *ngIf="form.controls.deployedTapedowns.controls[i].controls.offset_correction.invalid && (form.controls.deployedTapedowns.controls[i].controls.offset_correction.dirty || form.controls.deployedTapedowns.controls[i].controls.offset_correction.touched)"
-                                    class="alert alert-danger">
-                                    <div *ngIf="form.controls.deployedTapedowns.controls[i].controls.offset_correction.errors?.['incorrectValue']">
-                                        Offset Correction must be a numeric value.
+                            <!-- Offset correction column -->
+                            <ng-container matColumnDef="OffsetCorrection">
+                                <th mat-header-cell *matHeaderCellDef>Offset Correction</th>
+                                <td mat-cell *matCellDef="let tapedown; let i = index" [formGroupName]="i">
+                                    <mat-form-field appearance="fill">
+                                        <input matInput type="number" formControlName="offset_correction" [value]="tapedown.offset_correction"/>
+                                        <mat-icon matSuffix class="info-icon" matTooltip="From the datum location to the sensor orifice."
+                                        aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
+                                    </mat-form-field>
+                                    <!-- Offset Correction Validator -->
+                                    <div *ngIf="form.controls.deployedTapedowns.controls[i].controls.offset_correction.invalid && (form.controls.deployedTapedowns.controls[i].controls.offset_correction.dirty || form.controls.deployedTapedowns.controls[i].controls.offset_correction.touched)"
+                                        class="alert alert-danger">
+                                        <div *ngIf="form.controls.deployedTapedowns.controls[i].controls.offset_correction.errors?.['incorrectValue']">
+                                            Offset Correction must be a numeric value.
+                                        </div>
                                     </div>
-                                </div>
-                            </td>
-                        </ng-container>
+                                </td>
+                            </ng-container>
 
-                        <!-- WS column -->
-                        <ng-container matColumnDef="WaterSurface">
-                            <th mat-header-cell *matHeaderCellDef>Water Surface</th>
-                            <td mat-cell *matCellDef="let tapedown; let i = index" [formGroupName]="i">
-                                <mat-form-field appearance="fill">
-                                    <input matInput formControlName="water_surface" type="number" [value]="tapedown.water_surface"/>
-                                    <mat-icon matSuffix class="info-icon" matTooltip="From the datum location to the water surface."
-                                    aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
-                                </mat-form-field>
-                                <!-- Water Surface Validator -->
-                                <div *ngIf="form.controls.deployedTapedowns.controls[i].controls.water_surface.invalid && (form.controls.deployedTapedowns.controls[i].controls.water_surface.dirty || form.controls.deployedTapedowns.controls[i].controls.water_surface.touched)"
-                                    class="alert alert-danger">
-                                    <div *ngIf="form.controls.deployedTapedowns.controls[i].controls.water_surface.errors?.['incorrectValue']">
-                                        Water Surface must be a numeric value.
+                            <!-- WS column -->
+                            <ng-container matColumnDef="WaterSurface">
+                                <th mat-header-cell *matHeaderCellDef>Water Surface</th>
+                                <td mat-cell *matCellDef="let tapedown; let i = index" [formGroupName]="i">
+                                    <mat-form-field appearance="fill">
+                                        <input matInput formControlName="water_surface" type="number" [value]="tapedown.water_surface"/>
+                                        <mat-icon matSuffix class="info-icon" matTooltip="From the datum location to the water surface."
+                                        aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
+                                    </mat-form-field>
+                                    <!-- Water Surface Validator -->
+                                    <div *ngIf="form.controls.deployedTapedowns.controls[i].controls.water_surface.invalid && (form.controls.deployedTapedowns.controls[i].controls.water_surface.dirty || form.controls.deployedTapedowns.controls[i].controls.water_surface.touched)"
+                                        class="alert alert-danger">
+                                        <div *ngIf="form.controls.deployedTapedowns.controls[i].controls.water_surface.errors?.['incorrectValue']">
+                                            Water Surface must be a numeric value.
+                                        </div>
                                     </div>
-                                </div>
-                            </td>
-                        </ng-container>
+                                </td>
+                            </ng-container>
 
-                        <!-- GS column -->
-                        <ng-container matColumnDef="GroundSurface">
-                            <th mat-header-cell *matHeaderCellDef>Ground Surface</th>
-                            <td mat-cell *matCellDef="let tapedown; let i = index" [formGroupName]="i">
-                                <mat-form-field appearance="fill">
-                                    <input matInput formControlName="ground_surface" type="number" [value]="tapedown.ground_surface"/>
-                                    <mat-icon matSuffix class="info-icon" matTooltip="From the datum location to the ground surface."
-                                    aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
-                                </mat-form-field>
-                                <!-- Ground Surface Validator -->
-                                <div *ngIf="form.controls.deployedTapedowns.controls[i].controls.ground_surface.invalid && (form.controls.deployedTapedowns.controls[i].controls.ground_surface.dirty || form.controls.deployedTapedowns.controls[i].controls.ground_surface.touched)"
-                                    class="alert alert-danger">
-                                    <div *ngIf="form.controls.deployedTapedowns.controls[i].controls.ground_surface.errors?.['incorrectValue']">
-                                        Ground Surface must be a numeric value.
-                                    </div>
-                                </div>
-                            </td>
-                        </ng-container>
-    
-                        <tr mat-header-row *matHeaderRowDef="displayedTapedownColumns"></tr>
-                        <tr
-                            mat-row
-                            *matRowDef="let row; columns: displayedTapedownColumns"
-                            class="results-row"
-                        ></tr>
-                    </table>
-                </div>
-                <div class="note">
-                    <label>Note: these are not used for any calculations but are to facilitate field activities.</label>
-                </div>
-                <div *ngIf="sensor.instrument_status.length > 0">
-                    <div *ngFor="let instrument of sensor.instrument_status; let i = index" formArrayName="instrument_status">
-                        <div *ngIf="instrument.status === 'Deployed'">
-                            <div [formGroupName]="i">
-                                <mat-form-field appearance="fill">
-                                    <mat-label>Sensor Elevation</mat-label>
-                                    <input aria-label="Sensor Elevation" matInput type="number" formControlName="sensor_elevation" [value]="instrument.sensor_elevation">
-                                    <mat-icon matSuffix class="info-icon" matTooltip="Using the offset correction, elevation of the sensor orifice." 
+                            <!-- GS column -->
+                            <ng-container matColumnDef="GroundSurface">
+                                <th mat-header-cell *matHeaderCellDef>Ground Surface</th>
+                                <td mat-cell *matCellDef="let tapedown; let i = index" [formGroupName]="i">
+                                    <mat-form-field appearance="fill">
+                                        <input matInput formControlName="ground_surface" type="number" [value]="tapedown.ground_surface"/>
+                                        <mat-icon matSuffix class="info-icon" matTooltip="From the datum location to the ground surface."
                                         aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
-                                </mat-form-field>
-                                <!-- Sensor Elevation Validator -->
-                                <div *ngIf="form.controls.instrument_status.controls[i].controls.sensor_elevation.invalid && (form.controls.instrument_status.controls[i].controls.sensor_elevation.dirty || form.controls.instrument_status.controls[i].controls.sensor_elevation.touched)"
-                                    class="alert alert-danger">
-                                    <div *ngIf="form.controls.instrument_status.controls[i].controls.sensor_elevation.errors?.['incorrectValue']">
-                                        Sensor Elevation must be a numeric value.
+                                    </mat-form-field>
+                                    <!-- Ground Surface Validator -->
+                                    <div *ngIf="form.controls.deployedTapedowns.controls[i].controls.ground_surface.invalid && (form.controls.deployedTapedowns.controls[i].controls.ground_surface.dirty || form.controls.deployedTapedowns.controls[i].controls.ground_surface.touched)"
+                                        class="alert alert-danger">
+                                        <div *ngIf="form.controls.deployedTapedowns.controls[i].controls.ground_surface.errors?.['incorrectValue']">
+                                            Ground Surface must be a numeric value.
+                                        </div>
+                                    </div>
+                                </td>
+                            </ng-container>
+        
+                            <tr mat-header-row *matHeaderRowDef="displayedTapedownColumns"></tr>
+                            <tr
+                                mat-row
+                                *matRowDef="let row; columns: displayedTapedownColumns"
+                                class="results-row"
+                            ></tr>
+                        </table>
+                        <div class="note" *ngIf="form.controls.deployedTapedowns.length > 0">
+                            <label>Note: these are not used for any calculations but are to facilitate field activities.</label>
+                        </div>
+                    </div>
+                    <!-- Edit: sensor status fields for tapedown -->
+                    <!-- Create: Display these fields when reference datum is selected, Edit: always display these fields -->
+                    <div *ngIf="(editOrCreate === 'Create' && form.controls.deployedTapedowns.length > 0) || editOrCreate === 'Edit'">
+                        <div *ngIf="sensor.instrument_status.length > 0">
+                            <div *ngFor="let instrument of sensor.instrument_status; let i = index" formArrayName="instrument_status">
+                                <div *ngIf="instrument.status === 'Deployed'">
+                                    <div [formGroupName]="i">
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>Sensor Elevation</mat-label>
+                                            <input aria-label="Sensor Elevation" matInput type="number" formControlName="sensor_elevation" [value]="instrument.sensor_elevation">
+                                            <mat-icon matSuffix class="info-icon" matTooltip="Using the offset correction, elevation of the sensor orifice." 
+                                                aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
+                                        </mat-form-field>
+                                        <!-- Sensor Elevation Validator -->
+                                        <div *ngIf="form.controls.instrument_status.controls[i].controls.sensor_elevation.invalid && (form.controls.instrument_status.controls[i].controls.sensor_elevation.dirty || form.controls.instrument_status.controls[i].controls.sensor_elevation.touched)"
+                                            class="alert alert-danger">
+                                            <div *ngIf="form.controls.instrument_status.controls[i].controls.sensor_elevation.errors?.['incorrectValue']">
+                                                Sensor Elevation must be a numeric value.
+                                            </div>
+                                        </div>
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>Water Surface Elevation</mat-label>
+                                            <input aria-label="Water Surface Elevation" matInput type="number" formControlName="ws_elevation" [value]="instrument.ws_elevation">
+                                            <mat-icon matSuffix class="info-icon" matTooltip="Using the water surface tape down, elevation of the water surface." 
+                                                aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
+                                        </mat-form-field>
+                                        <!-- Water Surface Elevation Validator -->
+                                        <div *ngIf="form.controls.instrument_status.controls[i].controls.ws_elevation.invalid && (form.controls.instrument_status.controls[i].controls.ws_elevation.dirty || form.controls.instrument_status.controls[i].controls.ws_elevation.touched)"
+                                            class="alert alert-danger">
+                                            <div *ngIf="form.controls.instrument_status.controls[i].controls.ws_elevation.errors?.['incorrectValue']">
+                                                Water Surface Elevation must be a numeric value.
+                                            </div>
+                                        </div>
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>Ground Elevation</mat-label>
+                                            <input aria-label="Ground Elevation" matInput type="number" formControlName="gs_elevation" [value]="instrument.gs_elevation">
+                                            <mat-icon matSuffix class="info-icon" matTooltip="Using the ground surface tape down, elevation of the ground surface." 
+                                                aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
+                                        </mat-form-field>
+                                        <!-- Ground Surface Elevation Validator -->
+                                        <div *ngIf="form.controls.instrument_status.controls[i].controls.gs_elevation.invalid && (form.controls.instrument_status.controls[i].controls.gs_elevation.dirty || form.controls.instrument_status.controls[i].controls.gs_elevation.touched)"
+                                            class="alert alert-danger">
+                                            <div *ngIf="form.controls.instrument_status.controls[i].controls.gs_elevation.errors?.['incorrectValue']">
+                                                Ground Surface Elevation must be a numeric value.
+                                            </div>
+                                        </div>
+                                        <mat-form-field appearance="fill">
+                                            <mat-label>In Feet Above</mat-label>
+                                            <mat-select aria-label="In Feet Above" formControlName="vdatum_id">
+                                                <mat-option *ngFor="let datum of vDatumList" [value]="datum.datum_id">
+                                                {{datum.datum_name}}
+                                                </mat-option>
+                                            </mat-select>
+                                        </mat-form-field>
                                     </div>
                                 </div>
-                                <mat-form-field appearance="fill">
-                                    <mat-label>Water Surface Elevation</mat-label>
-                                    <input aria-label="Water Surface Elevation" matInput type="number" formControlName="ws_elevation" [value]="instrument.ws_elevation">
-                                    <mat-icon matSuffix class="info-icon" matTooltip="Using the water surface tape down, elevation of the water surface." 
-                                        aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
-                                </mat-form-field>
-                                <!-- Water Surface Elevation Validator -->
-                                <div *ngIf="form.controls.instrument_status.controls[i].controls.ws_elevation.invalid && (form.controls.instrument_status.controls[i].controls.ws_elevation.dirty || form.controls.instrument_status.controls[i].controls.ws_elevation.touched)"
-                                    class="alert alert-danger">
-                                    <div *ngIf="form.controls.instrument_status.controls[i].controls.ws_elevation.errors?.['incorrectValue']">
-                                        Water Surface Elevation must be a numeric value.
-                                    </div>
-                                </div>
-                                <mat-form-field appearance="fill">
-                                    <mat-label>Ground Elevation</mat-label>
-                                    <input aria-label="Ground Elevation" matInput type="number" formControlName="gs_elevation" [value]="instrument.gs_elevation">
-                                    <mat-icon matSuffix class="info-icon" matTooltip="Using the ground surface tape down, elevation of the ground surface." 
-                                        aria-label="Displays a tooltip when focused or hovered over">info</mat-icon>
-                                </mat-form-field>
-                                <!-- Ground Surface Elevation Validator -->
-                                <div *ngIf="form.controls.instrument_status.controls[i].controls.gs_elevation.invalid && (form.controls.instrument_status.controls[i].controls.gs_elevation.dirty || form.controls.instrument_status.controls[i].controls.gs_elevation.touched)"
-                                    class="alert alert-danger">
-                                    <div *ngIf="form.controls.instrument_status.controls[i].controls.gs_elevation.errors?.['incorrectValue']">
-                                        Ground Surface Elevation must be a numeric value.
-                                    </div>
-                                </div>
-                                <mat-form-field appearance="fill">
-                                    <mat-label>In Feet Above</mat-label>
-                                    <mat-select aria-label="In Feet Above" formControlName="vdatum_id">
-                                        <mat-option *ngFor="let datum of vDatumList" [value]="datum.datum_id">
-                                        {{datum.datum_name}}
-                                        </mat-option>
-                                    </mat-select>
-                                </mat-form-field>
+                            </div>
+                            <div class="note">
+                                <label>Note: these elevations are used in the sensor processing and the final products.</label>
                             </div>
                         </div>
                     </div>
-                </div>
-                <div class="note">
-                    <label>Note: these elevations are used in the sensor processing and the final products.</label>
-                </div>
+                    <!-- Create: sensor status fields for tapedown -->
+                </mat-expansion-panel>
                 <mat-divider></mat-divider>
-                <mat-radio-group class="radio-btn-group" [(value)]="vented" (change)="ventedChange($event.value)">
+                <!-- Vented (only if Sensor Type is Pressure Transducer)-->
+                <mat-radio-group *ngIf="form.controls.sensor_type_id.value === 1" class="radio-btn-group" [(value)]="vented" (change)="ventedChange($event.value)">
                     <mat-label class="form-header">Vented: </mat-label>
                     <mat-radio-button class="radio-button" value="Yes">Yes</mat-radio-button>
                     <mat-radio-button class="radio-button" value="No">No</mat-radio-button>
                 </mat-radio-group>
                 <mat-form-field appearance="fill">
                     <mat-label>Deployment Type</mat-label>
-                    <mat-select aria-label="Deployment Type" formControlName="deployment_type_id">
+                    <mat-select aria-label="Deployment Type" required formControlName="deployment_type_id">
                         <mat-option *ngFor="let type of deploymentTypes" [value]="type.deployment_type_id">
                         {{type.method}}
                         </mat-option>
@@ -333,8 +364,8 @@
                     </div>
                 </div>
                 <div class="ref-button-group">
-                    <button class="primary" mat-button cdkFocusInitial aria-label="Save" id="1" type="submit">Save</button>
-                    <button class="secondary cancel-btn" type="button" mat-stroked-button cdkFocusInitial aria-label="Cancel Edits" (click)="cancelForm('Deployed')">Cancel Edits</button>
+                    <button *ngIf="editOrCreate === 'Edit'" class="primary" mat-button cdkFocusInitial aria-label="Save" id="1" type="submit">Save</button>
+                    <button *ngIf="editOrCreate === 'Edit'" class="secondary cancel-btn" type="button" mat-stroked-button cdkFocusInitial aria-label="Cancel Edits" (click)="cancelForm('Deployed')">Cancel Edits</button>
                 </div>
             </mat-expansion-panel>
             <mat-expansion-panel hideToggle [expanded]="retrievedExpanded" (opened)="retrievedExpanded = true" (closed)="retrievedExpanded = false" *ngIf="sensor.statusType === 'Retrieved'">
@@ -867,7 +898,7 @@
                     <button class="secondary cancel-btn" type="button" mat-stroked-button cdkFocusInitial aria-label="Cancel Edits" (click)="cancelForm('Lost')">Cancel Edits</button>
                 </div>
             </mat-expansion-panel>
-            <mat-expansion-panel hideToggle [expanded]="filesExpanded" (opened)="filesExpanded = true" (closed)="filesExpanded = false">
+            <mat-expansion-panel hideToggle [expanded]="filesExpanded" (opened)="filesExpanded = true" (closed)="filesExpanded = false" *ngIf="editOrCreate === 'Edit'">
                 <mat-expansion-panel-header>
                     <mat-panel-title *ngIf="!filesExpanded" style="color: grey; font-weight: 500">
                         Sensor File Information
@@ -915,7 +946,7 @@
                     </table>
                 </div>
             </mat-expansion-panel>
-            <mat-expansion-panel hideToggle [expanded]="nwisExpanded"  (opened)="nwisExpanded = true" (closed)="nwisExpanded = false" *ngIf="sensor.statusType === 'Deployed'">
+            <mat-expansion-panel hideToggle [expanded]="nwisExpanded"  (opened)="nwisExpanded = true" (closed)="nwisExpanded = false" *ngIf="sensor.statusType === 'Deployed' && editOrCreate === 'Edit'">
                 <mat-expansion-panel-header>
                     <mat-panel-title *ngIf="!nwisExpanded" style="color: grey; font-weight: 500">
                         NWIS Connection
@@ -972,6 +1003,7 @@
     </mat-dialog-content>
     <mat-dialog-actions align="end">
         <div class="detail-section-buttons centered">
+            <button *ngIf="editOrCreate === 'Create'" class="primary" mat-button cdkFocusInitial aria-label="Deploy" id="1" type="submit">Deploy</button>
             <button mat-stroked-button class="secondary" [mat-dialog-close]="returnData" cdkFocusInitial aria-label="Cancel">Cancel</button>
             <!-- The mat-dialog-close directive optionally accepts a value as a result for the dialog. -->
         </div>

--- a/src/app/sensor-edit/sensor-edit.component.scss
+++ b/src/app/sensor-edit/sensor-edit.component.scss
@@ -169,6 +169,12 @@ table {
     margin: 5px;
 }
 
+.info-icon-white {
+    font-size: 20px;
+    color: #FFF;
+    text-align: right;
+}
+
 .inline-fields {
     display: inline-flex;
 }

--- a/src/app/sensor-edit/sensor-edit.component.scss
+++ b/src/app/sensor-edit/sensor-edit.component.scss
@@ -109,6 +109,11 @@ table {
     display: inline-flex;
 }
 
+.date-span {
+    height: 60%;
+    margin: auto;
+}
+
 .disabled {
     color: #000;
 }

--- a/src/app/sensor-edit/sensor-edit.component.spec.ts
+++ b/src/app/sensor-edit/sensor-edit.component.spec.ts
@@ -194,12 +194,14 @@ describe('SensorEditComponent', () => {
   });
 
   it('should split time stamp for formatting and set utc preview', () => {
+    component.editOrCreate = "Edit";
     component.setTimeAndDate();
     fixture.detectChanges();
     expect(component.sensor.instrument_status[0].hour).toEqual("01");
     expect(component.sensor.instrument_status[0].minute).toEqual("05");
     expect(component.sensor.instrument_status[0].ampm).toEqual("AM");
-    expect(component.sensor.instrument_status[0].utc_preview).toEqual("01/05/2022 01:05");
+    expect(component.sensor.instrument_status[0].utc_preview).toEqual("Wed, 05 Jan 2022 01:05:00 GMT");
+    component.editOrCreate = "";
   });
 
   it('should split initial files into nwis and other sensor file lists', () => {
@@ -256,20 +258,22 @@ describe('SensorEditComponent', () => {
   });
 
   it('should change am/pm', () => {
+    component.editOrCreate = "Edit";
     component.setTimeAndDate();
     component.changeTime(component.sensor.instrument_status[0]);
     fixture.detectChanges();
 
     // Initially AM, switch to PM
     expect(component.sensor.instrument_status[0].ampm).toEqual("PM");
-    expect(component.sensor.instrument_status[0].utc_preview).toEqual("01/05/2022 13:05");
+    expect(component.sensor.instrument_status[0].utc_preview).toEqual("Wed, 05 Jan 2022 13:05:00 GMT");
 
     component.changeTime(component.sensor.instrument_status[0]);
     fixture.detectChanges();
 
     // Initially AM, switch to PM
     expect(component.sensor.instrument_status[0].ampm).toEqual("AM");
-    expect(component.sensor.instrument_status[0].utc_preview).toEqual("01/05/2022 01:05");
+    expect(component.sensor.instrument_status[0].utc_preview).toEqual("Wed, 05 Jan 2022 01:05:00 GMT");
+    component.editOrCreate = "";
   });
 
   it('should set newStatusID value if different from initial status', () => {
@@ -368,11 +372,11 @@ describe('SensorEditComponent', () => {
     component.form.controls["instrument_status"].controls[0].controls["time_zone"].setValue("EST/EDT");
     component.setTimeZone(component.sensor.instrument_status[0]);
     fixture.detectChanges();
-    expect(component.sensor.instrument_status[0].time_zone).toEqual("EST/EDT");
-    expect(component.sensor.instrument_status[0].utc_preview).toEqual("01/05/2022 06:05");
+    expect(component.sensor.instrument_status[0].utc_preview).toEqual("Wed, 05 Jan 2022 06:05:00 GMT");
   });
 
   it('should set the utc preview value and change the timestamp', () => {
+    component.editOrCreate = "Edit";
     component.setTimeAndDate();
     component.initForm();
     component.previewUTC(component.sensor.instrument_status[0]);
@@ -381,7 +385,8 @@ describe('SensorEditComponent', () => {
     expect(
       component.form.controls["instrument_status"].controls[0].controls["time_stamp"].value).toEqual("2022-01-05T01:05:00");
     expect(
-      component.sensor.instrument_status[0].utc_preview).toEqual("01/05/2022 01:05");
+      component.sensor.instrument_status[0].utc_preview).toEqual("Wed, 05 Jan 2022 01:05:00 GMT");
+      component.editOrCreate = "";
   });
 
   it('should change vented form control value', () => {
@@ -623,6 +628,7 @@ describe('SensorEditComponent', () => {
     let removeSpy = spyOn(component.sensorEditService, 'deleteOPMeasure');
     let updateSpy = spyOn(component.sensorEditService, 'updateOPMeasure');
 
+    component.editOrCreate = "Edit";
     component.sendTapedownRequests(tapedownsToAdd, tapedownsToRemove, tapedownsToUpdate);
     fixture.detectChanges();
 
@@ -630,6 +636,7 @@ describe('SensorEditComponent', () => {
     expect(removeSpy).not.toHaveBeenCalled();
     expect(updateSpy).not.toHaveBeenCalled();
     expect(dialogSpy).not.toHaveBeenCalled();
+    component.editOrCreate = "Create";
   });
 
   it('should show alert if adding tapedowns fails', () => {
@@ -641,12 +648,13 @@ describe('SensorEditComponent', () => {
     let addSpy = spyOn(component.sensorEditService, 'addOPMeasure').and.returnValue(
       of([])
     );
-    
+    component.editOrCreate = "Edit";
     component.sendTapedownRequests(tapedownsToAdd, tapedownsToRemove, tapedownsToUpdate);
     fixture.detectChanges();
 
     expect(addSpy).toHaveBeenCalledTimes(1);
     expect(dialogSpy).toHaveBeenCalled();
+    component.editOrCreate = "";
   });
 
   it('should send requests and set return data to results', () => {
@@ -742,6 +750,7 @@ describe('SensorEditComponent', () => {
         of(collectCondResponse)
     );
 
+    component.editOrCreate = "Edit";
     let instrumentRequestSpy = spyOn(component.sensorEditService, 'putInstrument').and.returnValue(of(response));
     let instrumentStatusRequestSpy = spyOn(component.sensorEditService, 'putInstrumentStatus').and.returnValue(of(statusResponse));
     let tapedownSpy = spyOn(component, 'sendTapedownRequests');
@@ -760,5 +769,6 @@ describe('SensorEditComponent', () => {
     expect(instrumentStatusRequestSpy).toHaveBeenCalled();
     expect(tapedownSpy).toHaveBeenCalledTimes(1);
     expect(component.returnData.instrument_status[0]).toEqual(returnData.instrument_status[0]);
+    component.editOrCreate = "";
   });
 });

--- a/src/app/sensor-edit/sensor-edit.component.ts
+++ b/src/app/sensor-edit/sensor-edit.component.ts
@@ -1049,6 +1049,7 @@ export class SensorEditComponent implements OnInit {
     }else if(this.editOrCreate === "Create"){
       sensorSubmission.site_id = this.data.site_id;
       delete sensorSubmission.instrument_id;
+      /* istanbul ignore next */
       const deployInstrument = new Promise<string>((resolve, reject) => this.sensorEditService.postInstrument(sensorSubmission).subscribe(results => {
         if(results.length !== 0){
           // Format everything to send back to site
@@ -1119,6 +1120,7 @@ export class SensorEditComponent implements OnInit {
         }
       }));
 
+      /* istanbul ignore next */
       deployInstrument.then(() => {
         this.loading = false;
         let result = {result: this.returnData, editOrCreate: this.editOrCreate}

--- a/src/app/sensor-edit/sensor-edit.component.ts
+++ b/src/app/sensor-edit/sensor-edit.component.ts
@@ -1034,92 +1034,89 @@ export class SensorEditComponent implements OnInit {
       });
     }else if(this.editOrCreate === "Create"){
       sensorSubmission.site_id = this.data.site_id;
-      console.log(sensorSubmission)
-      // const deployInstrument = new Promise<string>((resolve, reject) => this.sensorEditService.postInstrument(sensorSubmission).subscribe(results => {
-      //   if(results.length !== 0){
-      //     // Format everything to send back to site
-      //     this.returnData = results;
-      //     this.returnData.sensorType = sensorSubmission.sensor_type_id !== null && sensorSubmission.sensor_type_id !== 0 ? this.sensorTypes.filter(function (i) { return i.sensor_type_id === sensorSubmission.sensor_type_id; })[0].sensor : "";
-      //     this.returnData.deploymentType = sensorSubmission.deployment_type_id !== null && sensorSubmission.deployment_type_id !== 0 ? this.deploymentTypes.filter(function (i) { return i.deployment_type_id === sensorSubmission.deployment_type_id; })[0].method : "";
-      //     this.returnData.instCollection = sensorSubmission.inst_collection_id !== null && sensorSubmission.inst_collection_id !== 0 ? this.collectConds.filter(function (i) { return i.id === sensorSubmission.inst_collection_id; })[0].condition : "";
-      //     this.returnData.housingType = sensorSubmission.housing_type_id !== null && sensorSubmission.housing_type_id !== 0 ? this.housingTypes.filter(function (i) { return i.housing_type_id === sensorSubmission.housing_type_id; })[0].type_name : "";
-      //     this.returnData.sensorBrand = sensorSubmission.sensor_brand_id !== null && sensorSubmission.sensor_brand_id !== 0 ? this.sensorBrands.filter(function (i) { return i.sensor_brand_id === sensorSubmission.sensor_brand_id; })[0].brand_name : "";
-      //     // Deployed statusType
-      //     this.returnData.statusType = this.sensor.statusType;
-      //     this.returnData.eventName = this.sensor.eventName;
+      const deployInstrument = new Promise<string>((resolve, reject) => this.sensorEditService.postInstrument(sensorSubmission).subscribe(results => {
+        if(results.length !== 0){
+          // Format everything to send back to site
+          this.returnData = results;
+          this.returnData.sensorType = sensorSubmission.sensor_type_id !== null && sensorSubmission.sensor_type_id !== 0 ? this.sensorTypes.filter(function (i) { return i.sensor_type_id === sensorSubmission.sensor_type_id; })[0].sensor : "";
+          this.returnData.deploymentType = sensorSubmission.deployment_type_id !== null && sensorSubmission.deployment_type_id !== 0 ? this.deploymentTypes.filter(function (i) { return i.deployment_type_id === sensorSubmission.deployment_type_id; })[0].method : "";
+          this.returnData.instCollection = sensorSubmission.inst_collection_id !== null && sensorSubmission.inst_collection_id !== 0 ? this.collectConds.filter(function (i) { return i.id === sensorSubmission.inst_collection_id; })[0].condition : "";
+          this.returnData.housingType = sensorSubmission.housing_type_id !== null && sensorSubmission.housing_type_id !== 0 ? this.housingTypes.filter(function (i) { return i.housing_type_id === sensorSubmission.housing_type_id; })[0].type_name : "";
+          this.returnData.sensorBrand = sensorSubmission.sensor_brand_id !== null && sensorSubmission.sensor_brand_id !== 0 ? this.sensorBrands.filter(function (i) { return i.sensor_brand_id === sensorSubmission.sensor_brand_id; })[0].brand_name : "";
+          // Deployed statusType
+          this.returnData.statusType = this.sensor.statusType;
+          this.returnData.eventName = this.sensor.eventName;
           // convert to UTC
           sensorStatusSubmission.time_stamp = this.timezonesService.convertTimezone(sensorStatusSubmission.time_zone, sensorStatusSubmission.time_stamp, sensorStatusSubmission.minute)
           sensorStatusSubmission.time_zone = "UTC";
           delete sensorStatusSubmission.ampm; delete sensorStatusSubmission.hour; delete sensorStatusSubmission.minute; delete sensorStatusSubmission.utc_preview;
-          console.log(sensorStatusSubmission)
-          // this.returnData.instrument_status = this.sensor.instrument_status;
-          // sensorStatusSubmission.instrument_id = results.instrument_id;
-          // this.sensorEditService.postInstrumentStatus(sensorStatusSubmission).subscribe(response => {
-            // if(response.length !== 0){
-            //   for(let statusType of self.allStatusTypes){
-            //     if(statusType.status_type_id === response.status_type_id) {
-            //       response.status = statusType.status;
-            //     }
-            //   }
-            //   this.returnData.instrument_status[0] = response;
+          this.returnData.instrument_status = this.sensor.instrument_status;
+          sensorStatusSubmission.instrument_id = results.instrument_id;
+          this.sensorEditService.postInstrumentStatus(sensorStatusSubmission).subscribe(response => {
+            if(response.length !== 0){
+              for(let statusType of self.allStatusTypes){
+                if(statusType.status_type_id === response.status_type_id) {
+                  response.status = statusType.status;
+                }
+              }
+              this.returnData.instrument_status[0] = response;
               let tapedownsToAdd = [];
               // No tapedowns to remove or update
               let tapedownsToRemove = [];
               let tapedownsToUpdate = [];
-              // tapedownsToAdd.forEach(tapedownToAdd => {
-              //   tapedownToAdd.instrument_status_id = response.instrument_status_id;
-              // });
+              tapedownsToAdd.forEach(tapedownToAdd => {
+                tapedownToAdd.instrument_status_id = response.instrument_status_id;
+              });
               
               tapedownsToAdd = this.addTapedowns(this.initDeployedTapedowns, deployedTapedowns);
-              console.log(tapedownsToAdd)
-              // this.sendTapedownRequests(tapedownsToAdd, tapedownsToRemove, tapedownsToUpdate);
+              this.sendTapedownRequests(tapedownsToAdd, tapedownsToRemove, tapedownsToUpdate);
 
-              // resolve("Success");
-            // }else{
-            //   this.dialog.open(ConfirmComponent, {
-            //     data: {
-            //       title: "Error saving Instrument Status.",
-            //       titleIcon: "close",
-            //       message: null,
-            //       confirmButtonText: "OK",
-            //       showCancelButton: false,
-            //     },
-            //   });
-            //   resolve("Success");
-            // }
-        //   })
-        // }
-        // else{
-        //   this.dialog.open(ConfirmComponent, {
-        //     data: {
-        //       title: "Error deploying Sensor.",
-        //       titleIcon: "close",
-        //       message: null,
-        //       confirmButtonText: "OK",
-        //       showCancelButton: false,
-        //     },
-        //   });
-        //   reject(new Error("Error deploying Sensor."));
-        // }
-      // }));
+              resolve("Success");
+            }else{
+              this.dialog.open(ConfirmComponent, {
+                data: {
+                  title: "Error saving Instrument Status.",
+                  titleIcon: "close",
+                  message: null,
+                  confirmButtonText: "OK",
+                  showCancelButton: false,
+                },
+              });
+              resolve("Success");
+            }
+          })
+        }
+        else{
+          this.dialog.open(ConfirmComponent, {
+            data: {
+              title: "Error deploying Sensor.",
+              titleIcon: "close",
+              message: null,
+              confirmButtonText: "OK",
+              showCancelButton: false,
+            },
+          });
+          reject(new Error("Error deploying Sensor."));
+        }
+      }));
 
-      // deployInstrument.then(() => {
-      //   this.loading = false;
-      //   let result = {result: this.returnData, editOrCreate: this.editOrCreate}
-      //   this.dialogRef.close(result);
-      //   this.dialog.open(ConfirmComponent, {
-      //     data: {
-      //       title: "Successfully deployed Sensor",
-      //       titleIcon: "check",
-      //       message: null,
-      //       confirmButtonText: "OK",
-      //       showCancelButton: false,
-      //     },
-      //   });
-      // }).catch(function(error) {
-      //   console.log(error.message);
-      //   self.loading = false;
-      // });
+      deployInstrument.then(() => {
+        this.loading = false;
+        let result = {result: this.returnData, editOrCreate: this.editOrCreate}
+        this.dialogRef.close(result);
+        this.dialog.open(ConfirmComponent, {
+          data: {
+            title: "Successfully deployed Sensor",
+            titleIcon: "check",
+            message: null,
+            confirmButtonText: "OK",
+            showCancelButton: false,
+          },
+        });
+      }).catch(function(error) {
+        console.log(error.message);
+        self.loading = false;
+      });
     }
 
   }

--- a/src/app/services/hwm-edit.service.ts
+++ b/src/app/services/hwm-edit.service.ts
@@ -72,6 +72,7 @@ export class HwmEditService {
         );
   }
 
+  /* istanbul ignore next */
   //Update a HWM
   public putHWM(hwm_id, hwm): Observable<any> {
     return this.httpClient

--- a/src/app/services/op-edit.service.ts
+++ b/src/app/services/op-edit.service.ts
@@ -122,6 +122,7 @@ export class OpEditService {
           );
     }
 
+    /* istanbul ignore next */
     //Get Datum Location OP Measurements
     public getOPMeasurements(opID): Observable<any> {
         return this.httpClient

--- a/src/app/services/sensor-edit.service.ts
+++ b/src/app/services/sensor-edit.service.ts
@@ -74,6 +74,24 @@ export class SensorEditService {
         );
   }
 
+  /* istanbul ignore next */
+  //Deploy/create instrument
+  public postInstrument(instrument): Observable<any> {
+    return this.httpClient
+        .post(APP_SETTINGS.API_ROOT + 'Instruments.json', instrument, {
+          headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+      })
+        .pipe(
+            tap((response) => {
+                console.log(
+                    'postInstrument response received'
+                );
+                return response;
+            }),
+            catchError(this.handleError<any>('postInstrument', []))
+        );
+  }
+
   //Update instrument status
   public putInstrumentStatus(instrumentStatusID: string, instrumentStatus): Observable<any> {
     return this.httpClient
@@ -88,6 +106,24 @@ export class SensorEditService {
                 return response;
             }),
             catchError(this.handleError<any>('putInstrumentStatus', []))
+        );
+  }
+
+  /* istanbul ignore next */
+  //Create instrument status
+  public postInstrumentStatus(instrumentStatus): Observable<any> {
+    return this.httpClient
+        .post(APP_SETTINGS.API_ROOT + 'InstrumentStatus.json', instrumentStatus, {
+          headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+      })
+        .pipe(
+            tap((response) => {
+                console.log(
+                    'postInstrumentStatus response received'
+                );
+                return response;
+            }),
+            catchError(this.handleError<any>('postInstrumentStatus', []))
         );
   }
 

--- a/src/app/services/sensor.service.ts
+++ b/src/app/services/sensor.service.ts
@@ -41,6 +41,7 @@ export class SensorService {
             );
     }
 
+    /* istanbul ignore next */
     // retrieve all site sensors for an event -- currently not in use
     public getSiteEventInstruments(siteID, eventID): Observable<Event> {
         return this.httpClient

--- a/src/app/site-details/site-details.component.html
+++ b/src/app/site-details/site-details.component.html
@@ -470,7 +470,7 @@
                         <mat-card class="mat-elevation-z0 header-card">
                             <p>Reference Datums ({{referenceDatums.length}})</p>
                             <button *ngIf="role === '1' || role === '2' || role === '3'" mat-button (click)="openRefDatumEditDialog(null)"
-                                aria-label="Add Reference Datum"><mat-icon class="add-buttons">add</mat-icon>
+                                aria-label="Add Reference Datum"><mat-icon matTooltip="Add a Reference Datum" matTooltipPosition="before" class="add-buttons">add</mat-icon>
                             </button>
                         </mat-card>
                         <div class="tableContainer" *ngIf="referenceDatums !== undefined; else noRMTable">
@@ -611,7 +611,12 @@
                         <mat-paginator [hidden]="referenceDatums === undefined || referenceDatums.length === 0" #paginator [pageSizeOptions]="[5, 10, 25]" class="results-paginator"></mat-paginator>
                     </mat-tab>
                     <mat-tab label="Sensors ({{siteFullInstruments.length}})">
-                        <mat-card class="mat-elevation-z0 header-card"><p>Sensors ({{siteFullInstruments.length}})</p></mat-card>
+                        <mat-card class="mat-elevation-z0 header-card">
+                            <p>Sensors ({{siteFullInstruments.length}})</p>
+                            <button *ngIf="currentEvent !== null && role === '1' || role === '2' || role === '3'" mat-button (click)="openSensorEditDialog(null)"
+                                aria-label="Add Sensor"><mat-icon class="add-buttons" matTooltip="Deploy a new Sensor" matTooltipPosition="before">add</mat-icon>
+                            </button>
+                        </mat-card>
                         <mat-card class="mat-elevation-z0 event-alert" *ngIf="currentEvent === 0"><mat-icon class="warning-icon">warning</mat-icon><p>To deploy or retrieve a sensor, first choose an Event above.</p></mat-card>
                         <div class="tableContainer" *ngIf="siteFullInstruments !== undefined; else noSensorTable">
                             <table *ngIf="siteFullInstruments.length > 0; else noSensorTable"
@@ -818,7 +823,7 @@
                         <mat-card class="mat-elevation-z0 header-card">
                             <p>High Water Marks ({{hwm.length}})</p>
                             <button *ngIf="currentEvent !== null && (role === '1' || role === '2' || role === '3')" mat-button (click)="openHWMEditDialog(null)"
-                                aria-label="Add HWM"><mat-icon class="add-buttons">add</mat-icon>
+                                aria-label="Add HWM"><mat-icon matTooltip="Add a HWM" matTooltipPosition="before" class="add-buttons">add</mat-icon>
                             </button>
                         </mat-card>
                         <mat-card class="mat-elevation-z0 event-alert" *ngIf="currentEvent === null"><mat-icon class="warning-icon">warning</mat-icon><p>To create a HWM, first choose an Event above.</p></mat-card>

--- a/src/app/site-details/site-details.component.ts
+++ b/src/app/site-details/site-details.component.ts
@@ -1300,18 +1300,24 @@ export class SiteDetailsComponent implements OnInit {
                 files: this.sensorFilesDataSource.data,
                 site_id: this.site.site_id,
                 siteRefMarks: this.refMarkDataSource.data,
+                event_id: this.currentEvent,
+                event: this.event,
             },
             width: '100%',
             autoFocus: false
         });
         dialogRef.afterClosed().subscribe((result) => {
-            if (result){
+            if (result.result && result.editOrCreate === "Edit"){
                 this.sensorDataSource.data.forEach(function(sensor, i){
-                    if(sensor.instrument_id === result.instrument_id){
-                        self.sensorDataSource.data[i] = result; 
+                    if(sensor.instrument_id === result.result.instrument_id){
+                        self.sensorDataSource.data[i] = result.result; 
                         self.sensorDataSource.data = [...self.sensorDataSource.data];
                     }
                 })
+            }
+            else if(result.result && result.editOrCreate === "Create") {
+                self.sensorDataSource.data.push(result.result); 
+                self.sensorDataSource.data = [...self.sensorDataSource.data];
             }
         });
     }

--- a/src/app/site-details/site-details.component.ts
+++ b/src/app/site-details/site-details.component.ts
@@ -461,6 +461,7 @@ export class SiteDetailsComponent implements OnInit {
                                         })
                                     })
                                     this.sensorDataSource.data = this.siteFullInstruments;
+                                    console.log(this.sensorDataSource.data)
                                     this.sensorDataSource.paginator = this.sensorPaginator;
                                     this.getSensorsForMap();
                                 }

--- a/src/app/user-management/user-management.component.ts
+++ b/src/app/user-management/user-management.component.ts
@@ -141,6 +141,7 @@ export class UserManagementComponent implements OnInit {
     }
   }
 
+  /* istanbul ignore next */
   sortData(sort: Sort) {
     const data = this.userDataSource.data.slice();
     if (!sort.active || sort.direction === '') {
@@ -209,6 +210,7 @@ export class UserManagementComponent implements OnInit {
     this.userDataSource.filter = filterValue.trim().toLowerCase();
   }
 
+  /* istanbul ignore next */
   openNewUserDialog(): void {
     const dialogRef = this.dialog.open(AddUserDialogComponent, {
       data: {


### PR DESCRIPTION
The Deploy Sensor modal initially populates the date/time with the current time in UTC rather than the user's current local time.

Also redid some timezone conversion stuff in the sensor edit component and fixed a bug in form reset when clicking "Cancel Edits" in the sensor edit modal (the timezone and am/pm value weren't resetting).