### PR TITLE
342 - add ability to delete a peak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  -  Improved responsiveness of tables in details modals
  -  Autopopulate source and agency when adding file in site edit form
  -  Disabled add button when no event selected for Peaks, Sensors, HWMs and files (except site files)
+ -  Disabled peak edit when no event selected
 
  
  ### Fixed
@@ -34,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  -  Time reset in sensor edit modal when Cancel Edits is clicked
  -  Time validation in sensor edit
  -  Inability to login after logging out
+ -  Duplicated disabled buttons when incorrect role and no event selected
 
 ## [v0.7.0](https://github.com/USGS-WiM/stnweb2/releases/tag/v0.7.0) - 2022-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  -  Added ability to delete sensors
  -  Alert for deploying and retrieving sensors when no event selected
  -  Added ability to create a peak
+ -  Added ability to delete a peak
  
 ### Changed
 

--- a/src/app/peak-edit/peak-edit.component.html
+++ b/src/app/peak-edit/peak-edit.component.html
@@ -28,9 +28,9 @@
                         >HWM {{hwm.hwm_id}} - {{hwm.elev_ft || '--'}} ft</mat-checkbox
                     >
                     <div class="button-group">
-                        <button mat-button type="button" class="secondary" (click)="showHWMDetails(i)"><mat-icon class="info-icon" matTooltip="Show Details">info</mat-icon></button>
-                        <button mat-button *ngIf="hwm.elev_ft" class="secondary" type="button" (click)="primaryHWM(hwm)" class="right-button"><mat-icon class="check-icon" matTooltip="Set as Primary">check_circle_outline</mat-icon></button>
-                        <button mat-button *ngIf="!hwm.elev_ft" class="secondary" type="button" (click)="showIncompleteHWMInfo()" class="right-button"><mat-icon class="warning-icon" matTooltip="Incomplete">warning</mat-icon></button>
+                        <button mat-button type="button" (click)="showHWMDetails(i)"><mat-icon class="info-icon" matTooltip="Show Details">info</mat-icon></button>
+                        <button mat-button *ngIf="hwm.elev_ft" type="button" (click)="primaryHWM(hwm)" class="right-button"><mat-icon class="check-icon" matTooltip="Set as Primary">check_circle_outline</mat-icon></button>
+                        <button mat-button *ngIf="!hwm.elev_ft" type="button" (click)="showIncompleteHWMInfo()" class="right-button"><mat-icon class="warning-icon" matTooltip="Incomplete">warning</mat-icon></button>
                     </div>
                 </div>
                 <!-- HWM Details, not shown unless Show Details clicked -->

--- a/src/app/services/peak-edit.service.ts
+++ b/src/app/services/peak-edit.service.ts
@@ -78,7 +78,8 @@ export class PeakEditService {
             catchError(this.handleError<any>('postPeak', []))
         );
   }
-
+  
+  /* istanbul ignore next */
   // Delete peak
   public deletePeak(peak_summary_id): Observable<any> {
     return this.httpClient
@@ -129,6 +130,23 @@ export class PeakEditService {
             catchError(this.handleError<any>('updateHWM', []))
         );
   }
+
+  //Get hwm
+  public getHWM(hwmID): Observable<any> {
+    return this.httpClient
+        .get(APP_SETTINGS.API_ROOT + 'HWMs/' + hwmID + '.json', {
+            headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+        })
+        .pipe(
+            tap((response) => {
+                console.log(
+                    'getHWM response received'
+                );
+                return response;
+            }),
+            catchError(this.handleError<any>('getHWM', []))
+        );
+}
 
   /**
      * Handle Http operation that failed.

--- a/src/app/services/peak-edit.service.ts
+++ b/src/app/services/peak-edit.service.ts
@@ -60,6 +60,23 @@ export class PeakEditService {
         );
   }
 
+  // Update peak
+  public deletePeak(peak_summary_id): Observable<any> {
+    return this.httpClient
+        .delete(APP_SETTINGS.API_ROOT + 'PeakSummaries/' + peak_summary_id + '.json', {
+          headers: APP_SETTINGS.AUTH_JSON_HEADERS,
+        })
+        .pipe(
+            tap((response) => {
+                console.log(
+                    'deletePeak response received'
+                );
+                return response;
+            }),
+            catchError(this.handleError<any>('deletePeak', []))
+        );
+  }
+
   // Update Data File
   public updateDF(data_file_id, df): Observable<any> {
     return this.httpClient

--- a/src/app/site-details/site-details.component.html
+++ b/src/app/site-details/site-details.component.html
@@ -14,7 +14,7 @@
                         <button *ngIf="!deleteDisabled" mat-stroked-button class="delete-button delete"><mat-icon>delete_forever</mat-icon> Delete Site</button>
                         <span *ngIf="deleteDisabled" matTooltip="To delete a site, please contact a STN administrator." 
                         aria-label="Displays a tooltip when focused or hovered over">
-                            <button mat-stroked-button disabled class="delete-button delete"><mat-icon>delete_forever</mat-icon> Delete Site</button>
+                            <button mat-stroked-button disabled class="delete-button disabled-border"><mat-icon>delete_forever</mat-icon> Delete Site</button>
                         </span>
                     </div>
                 </div>
@@ -532,10 +532,13 @@
                                             aria-label="Edit"><mat-icon class="edit-icon">edit</mat-icon>
                                             <span> Edit</span>
                                         </button>
-                                        <button mat-menu-item class="delete-borderless" (click)="deleteRD(row)"
+                                        <button *ngIf="role === '1' || role === '2' || role === '3'" mat-menu-item class="delete-borderless" (click)="deleteRD(row)"
                                             aria-label="Delete"><mat-icon class="delete-borderless">delete_forever</mat-icon>
                                             <span>Delete</span>
                                         </button>
+                                        <span *ngIf="role !== '1' && role !== '2' && role !== '3'">
+                                            <button mat-menu-item disabled aria-label="Delete" class="disabled-borderless"><mat-icon>delete_forever</mat-icon>Delete</button>
+                                        </span>
                                     </mat-menu>
                                     </td>
                                 </ng-container>
@@ -717,10 +720,13 @@
                                             aria-label="Edit"><mat-icon class="edit-icon">edit</mat-icon>
                                             <span> Edit</span>
                                         </button>
-                                        <button mat-menu-item  class="delete-borderless" (click)="deleteSensor(row)"
+                                        <button mat-menu-item *ngIf="role === '1' || role === '2' || role === '3'" class="delete-borderless" (click)="deleteSensor(row)"
                                             aria-label="Delete"><mat-icon class="delete-borderless">delete_forever</mat-icon>
                                             <span>Delete</span>
                                         </button>
+                                        <span *ngIf="role !== '1' && role !== '2' && role !== '3'">
+                                            <button mat-menu-item disabled aria-label="Delete" class="disabled-borderless"><mat-icon>delete_forever</mat-icon>Delete</button>
+                                        </span>
                                     </mat-menu>
                                     </td>
                                 </ng-container>
@@ -912,10 +918,13 @@
                                                 aria-label="Edit"><mat-icon class="edit-icon">edit</mat-icon>
                                                 <span> Edit</span>
                                             </button>
-                                            <button mat-menu-item class="delete-borderless" (click)="deleteHWM(row)"
+                                            <button mat-menu-item class="delete-borderless" *ngIf="role === '1' || role === '2' || role === '3'" (click)="deleteHWM(row)"
                                                 aria-label="Delete"><mat-icon class="delete-borderless">delete_forever</mat-icon>
                                                 <span>Delete</span>
                                             </button>
+                                            <span *ngIf="role !== '1' && role !== '2' && role !== '3'">
+                                                <button mat-menu-item disabled aria-label="Delete" class="disabled-borderless"><mat-icon>delete_forever</mat-icon>Delete</button>
+                                            </span>
                                         </mat-menu>
                                     </td>
                                 </ng-container>
@@ -1085,10 +1094,14 @@
                                                 aria-label="Edit"><mat-icon class="edit-icon">edit</mat-icon>
                                                 <span> Edit</span>
                                             </button>
-                                            <button mat-menu-item class="delete-borderless" [disabled]="role !== '1'" (click)="deletePeak(row)"
+                                            <button mat-menu-item *ngIf="role === '1'" class="delete-borderless" [disabled]="role !== '1'" (click)="deletePeak(row)"
                                                 aria-label="Delete"><mat-icon class="delete-borderless">delete_forever</mat-icon>
                                                 <span>Delete</span>
-                                        </button>
+                                            </button>
+                                            <span *ngIf="role !== '1'" matTooltip="To delete a peak, please contact a STN administrator." 
+                                            aria-label="Displays a tooltip when focused or hovered over">
+                                                <button mat-menu-item disabled aria-label="Delete" class="disabled-borderless"><mat-icon>delete_forever</mat-icon>Delete</button>
+                                            </span>
                                         </mat-menu>
                                     </td>
                                 </ng-container>

--- a/src/app/site-details/site-details.component.html
+++ b/src/app/site-details/site-details.component.html
@@ -1079,7 +1079,7 @@
                                                 aria-label="Edit"><mat-icon class="edit-icon">edit</mat-icon>
                                                 <span> Edit</span>
                                             </button>
-                                            <button mat-menu-item class="delete-borderless"
+                                            <button mat-menu-item class="delete-borderless" (click)="deletePeak(row)"
                                                 aria-label="Delete"><mat-icon class="delete-borderless">delete_forever</mat-icon>
                                                 <span>Delete</span>
                                         </button>

--- a/src/app/site-details/site-details.component.html
+++ b/src/app/site-details/site-details.component.html
@@ -1079,7 +1079,7 @@
                                                 aria-label="Edit"><mat-icon class="edit-icon">edit</mat-icon>
                                                 <span> Edit</span>
                                             </button>
-                                            <button mat-menu-item class="delete-borderless" (click)="deletePeak(row)"
+                                            <button mat-menu-item class="delete-borderless" [disabled]="role !== '1'" (click)="deletePeak(row)"
                                                 aria-label="Delete"><mat-icon class="delete-borderless">delete_forever</mat-icon>
                                                 <span>Delete</span>
                                         </button>

--- a/src/app/site-details/site-details.component.html
+++ b/src/app/site-details/site-details.component.html
@@ -623,13 +623,9 @@
                             <button *ngIf="currentEvent !== null && role === '1' || role === '2' || role === '3'" mat-button (click)="openSensorEditDialog(null)"
                                 aria-label="Add Sensor"><mat-icon class="add-buttons" matTooltip="Deploy a new Sensor" matTooltipPosition="before">add</mat-icon>
                             </button>
-                            <!-- Disabled button with event tooltip -->
-                            <button mat-button *ngIf="currentEvent === null" disabled class="disabled-icon"
-                                aria-label="Add Sensor"><mat-icon matTooltip="Select an event to deploy a Sensor" matTooltipPosition="before">add</mat-icon>
-                            </button>
-                            <!-- Disabled button with role tooltip -->
-                            <button mat-button *ngIf="(role !== '1' && role !== '2' && role !== '3')" disabled class="disabled-icon"
-                                aria-label="Add Sensor"><mat-icon matTooltip="To deploy a Sensor, please contact a STN administrator." matTooltipPosition="before">add</mat-icon>
+                            <!-- Disabled button with tooltip -->
+                            <button mat-button *ngIf="currentEvent === null || (role !== '1' && role !== '2' && role !== '3')" disabled class="disabled-icon"
+                                aria-label="Add Sensor"><mat-icon [matTooltip]="(role !== '1' && role !== '2' && role !== '3') ? 'To deploy a Sensor, please contact a STN administrator.' : 'Select an event to deploy a Sensor.'" matTooltipPosition="before">add</mat-icon>
                             </button>
                         </mat-card>
                         <mat-card class="mat-elevation-z0 event-alert" *ngIf="currentEvent === null"><mat-icon class="warning-icon">warning</mat-icon><p>To deploy or retrieve a sensor, first choose an Event above.</p></mat-card>
@@ -715,7 +711,7 @@
                                     </th>
                                     <td mat-cell *matCellDef="let row">
                                     <button mat-stroked-button class="view-details-btn secondary" (click)="openSensorDetailsDialog(row)"
-                                        aria-label="Edit">View Details
+                                        aria-label="View Details">View Details
                                     </button>
                                     <button mat-stroked-button class="edit-details-btn secondary" (click)="openSensorEditDialog(row)"
                                         aria-label="Edit"><mat-icon class="edit-icon">edit</mat-icon> Edit
@@ -843,13 +839,9 @@
                             <button *ngIf="currentEvent !== null && (role === '1' || role === '2' || role === '3')" mat-button (click)="openHWMEditDialog(null)"
                                 aria-label="Add HWM"><mat-icon matTooltip="Add a HWM" matTooltipPosition="before" class="add-buttons">add</mat-icon>
                             </button>
-                            <!-- Disabled button with event tooltip -->
-                            <button mat-button *ngIf="currentEvent === null" disabled class="disabled-icon"
-                                aria-label="Add HWM"><mat-icon matTooltip="Select an event to add a HWM" matTooltipPosition="before">add</mat-icon>
-                            </button>
-                            <!-- Disabled button with role tooltip -->
-                            <button mat-button *ngIf="(role !== '1' && role !== '2' && role !== '3')" disabled class="disabled-icon"
-                                aria-label="Add HWM"><mat-icon matTooltip="To add a HWM, please contact a STN administrator." matTooltipPosition="before">add</mat-icon>
+                            <!-- Disabled button with tooltip -->
+                            <button mat-button *ngIf="currentEvent === null || (role !== '1' && role !== '2' && role !== '3')" disabled class="disabled-icon"
+                                aria-label="Add HWM"><mat-icon [matTooltip]="(role !== '1' && role !== '2' && role !== '3') ? 'To add a HWM, please contact a STN administrator.' : 'Select an event to add a HWM'" matTooltipPosition="before">add</mat-icon>
                             </button>
                         </mat-card>
                         <mat-card class="mat-elevation-z0 event-alert" *ngIf="currentEvent === null"><mat-icon class="warning-icon">warning</mat-icon><p>To create a HWM, first choose an Event above.</p></mat-card>
@@ -1043,12 +1035,8 @@
                                 aria-label="Add Peak Summary"><mat-icon mat-icon matTooltip="Create a Peak" matTooltipPosition="before" class="add-buttons">add</mat-icon>
                             </button>
                             <!-- Disabled button with event tooltip -->
-                            <button *ngIf="currentEvent === null" disabled class="disabled-icon" mat-button
-                                aria-label="Add Peak Summary"><mat-icon mat-icon matTooltip="Select an event to create a Peak" matTooltipPosition="before">add</mat-icon>
-                            </button>
-                            <!-- Disabled button with role tooltip -->
-                            <button *ngIf="(role !== '1' && role !== '2' && role !== '3')" disabled class="disabled-icon" mat-button
-                                aria-label="Add Peak Summary"><mat-icon matTooltip="To create a Peak, please contact a STN administrator." matTooltipPosition="before">add</mat-icon>
+                            <button *ngIf="currentEvent === null || (role !== '1' && role !== '2' && role !== '3')" disabled class="disabled-icon" mat-button
+                                aria-label="Add Peak Summary"><mat-icon mat-icon [matTooltip]="(role !== '1' && role !== '2' && role !== '3') ? 'To create a Peak, please contact a STN administrator.' : 'Select an event to create a Peak'" matTooltipPosition="before">add</mat-icon>
                             </button>
                         </mat-card>
                         <div class="tableContainer" *ngIf="peaks !== undefined; else noPeakTable">
@@ -1107,9 +1095,15 @@
                                         <button mat-stroked-button class="view-details-btn secondary" (click)="openPeaksDetailsDialog(row)"
                                             aria-label="View Details"><mat-icon>search</mat-icon> View Details
                                         </button>
-                                        <button mat-stroked-button class="edit-details-btn secondary" (click)="openPeaksEditDialog(row)"
+                                        <button mat-stroked-button *ngIf="currentEvent !== null" class="edit-details-btn secondary" (click)="openPeaksEditDialog(row)"
                                         aria-label="Edit"><mat-icon class="edit-icon">edit</mat-icon> Edit
                                         </button>
+                                        <!-- Edit disabled desktop -->
+                                        <span *ngIf="currentEvent === null" matTooltip="Select an event to edit a peak." aria-label="Edit">
+                                            <button mat-stroked-button disabled class="disabled-border"
+                                                aria-label="Edit"><mat-icon class="edit-icon">edit</mat-icon> Edit
+                                            </button>
+                                        </span>
                                         <button mat-icon-button [matMenuTriggerFor]="menu" aria-label="Icon-button with a menu">
                                             <mat-icon>more_vert</mat-icon>
                                         </button>
@@ -1118,15 +1112,23 @@
                                                 aria-label="View Details"><mat-icon>search</mat-icon>
                                                 <span> View Details</span>
                                             </button>
-                                            <button mat-menu-item class="edit-details-mobile" (click)="openPeaksEditDialog(row)"
+                                            <button mat-menu-item *ngIf="currentEvent !== null" class="edit-details-mobile" (click)="openPeaksEditDialog(row)"
                                                 aria-label="Edit"><mat-icon class="edit-icon">edit</mat-icon>
                                                 <span> Edit</span>
                                             </button>
-                                            <button mat-menu-item *ngIf="role === '1'" class="delete-borderless" [disabled]="role !== '1'" (click)="deletePeak(row)"
+                                            <!-- Edit disabled mobile -->
+                                            <span *ngIf="currentEvent === null" matTooltip="Select an event to edit a peak." aria-label="Edit">
+                                                <button mat-menu-item disabled class="edit-details-mobile disabled-borderless"
+                                                    aria-label="Edit"><mat-icon matTooltip="Select an event to edit a peak." class="edit-icon">edit</mat-icon>
+                                                    <span> Edit</span>
+                                                </button>
+                                            </span>
+                                            <button mat-menu-item *ngIf="role === '1' && currentEvent !== null" class="delete-borderless" [disabled]="role !== '1'" (click)="deletePeak(row)"
                                                 aria-label="Delete"><mat-icon class="delete-borderless">delete_forever</mat-icon>
                                                 <span>Delete</span>
                                             </button>
-                                            <span *ngIf="role !== '1'" matTooltip="To delete a peak, please contact a STN administrator." 
+                                            <!-- Disabled role -->
+                                            <span *ngIf="role !== '1' || currentEvent === null" [matTooltip]="role !=='1' ? 'To delete a peak, please contact a STN administrator.' : 'Select an event to delete a peak.'" 
                                             aria-label="Displays a tooltip when focused or hovered over">
                                                 <button mat-menu-item disabled aria-label="Delete" class="disabled-borderless"><mat-icon>delete_forever</mat-icon>Delete</button>
                                             </span>

--- a/src/app/site-details/site-details.component.ts
+++ b/src/app/site-details/site-details.component.ts
@@ -1559,13 +1559,11 @@ export class SiteDetailsComponent implements OnInit {
         }
 
         let updateDFwoPeakID = function(dfID) {
-            console.log(dfID)
             self.siteService.getDataFile(dfID).subscribe((dfToRemove) => {
                 dfToRemove.peak_summary_id = null;
-                console.log(dfToRemove)
-                // self.peakEditService.updateDF(dfToRemove.data_file_id, dfToRemove).subscribe(response => {
-                //     console.log(response);
-                // });
+                self.peakEditService.updateDF(dfToRemove.data_file_id, dfToRemove).subscribe(response => {
+                    console.log(response);
+                });
             });
         }
 
@@ -1581,8 +1579,8 @@ export class SiteDetailsComponent implements OnInit {
         dialogRef.afterClosed().subscribe((result) => {
             if(result) {
                 // Delete hwm
-                // this.peakEditService.deletePeak(row.peak_summary_id).subscribe((results) => {
-                //     if(results === null){
+                this.peakEditService.deletePeak(row.peak_summary_id).subscribe((results) => {
+                    if(results === null){
                         this.peakEditService.getPeakDataFiles(row.peak_summary_id).subscribe(dfResults => {
                             peakDFs = dfResults;
                             // Get list of sensor files
@@ -1607,17 +1605,15 @@ export class SiteDetailsComponent implements OnInit {
                             // Get selected hwms for this peak
                             hwms.forEach(function(hwm, i){
                                 if(hwm.peak_summary_id === row.peak_summary_id){
-                                hwms[i].selected = true;
+                                    hwms[i].selected = true;
                                 }else{
-                                hwms[i].selected = false;
+                                    hwms[i].selected = false;
                                 }
                             })
                             
                             //remove peakID and PUT selected files
                             sensorFiles.forEach((file) => {
                                 if (file.selected){
-                                    console.log(file)
-                                    console.log(file.selected)
                                     updateDFwoPeakID(file.data_file_id);
                                 }
                             })
@@ -1627,8 +1623,9 @@ export class SiteDetailsComponent implements OnInit {
                                 if (hwm.selected) {
                                     hwm.peak_summary_id = null;
                                     let formattedHWM = formatHWM(hwm); //need to format it to remove all the site stuff
-                                    console.log(formattedHWM)
-                                    // this.peakEditService.updateHWM(formattedHWM.hwm_id, formattedHWM);
+                                    self.peakEditService.updateHWM(formattedHWM.hwm_id, formattedHWM).subscribe(response => {
+                                        console.log(response);
+                                    });
                                 }
                             });
                         });
@@ -1640,28 +1637,28 @@ export class SiteDetailsComponent implements OnInit {
                             }
                         })
                         // success
-                        // this.dialog.open(ConfirmComponent, {
-                        //     data: {
-                        //     title: "",
-                        //     titleIcon: "close",
-                        //     message: "Successfully removed Peak",
-                        //     confirmButtonText: "OK",
-                        //     showCancelButton: false,
-                        //     },
-                        // });
-                    // }else{
-                    //     // error
-                    //     this.dialog.open(ConfirmComponent, {
-                    //         data: {
-                    //         title: "Error",
-                    //         titleIcon: "close",
-                    //         message: "Error removing Peak",
-                    //         confirmButtonText: "OK",
-                    //         showCancelButton: false,
-                    //         },
-                    //     });
-                    // }
-            //     })
+                        this.dialog.open(ConfirmComponent, {
+                            data: {
+                            title: "",
+                            titleIcon: "close",
+                            message: "Successfully removed Peak",
+                            confirmButtonText: "OK",
+                            showCancelButton: false,
+                            },
+                        });
+                    }else{
+                        // error
+                        this.dialog.open(ConfirmComponent, {
+                            data: {
+                            title: "Error",
+                            titleIcon: "close",
+                            message: "Error removing Peak",
+                            confirmButtonText: "OK",
+                            showCancelButton: false,
+                            },
+                        });
+                    }
+                })
             }
         });
     }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -29,8 +29,17 @@ $stn-app-theme: mat-light-theme(
     border: 1px solid #ce0000 !important;
 }
 
+.disabled-border {
+    color: rgba(0, 0, 0, 0.38) !important;
+    border: 1px solid rgba(0, 0, 0, 0.38) !important;
+}
+
 .delete-borderless {
     color: #ce0000 !important;
+}
+
+.disabled-borderless {
+    color: rgba(0, 0, 0, 0.38) !important;
 }
 
 .add {


### PR DESCRIPTION
- event must be selected and role =1
- disabled editing for peak when no event selected
- fixed bug where disabled buttons were duplicated if no event was selected and role didn't have permissions. (e.g. delete button should only show up once when logged in with test field user and no event is selected).